### PR TITLE
Fix DashboardLog to be from the new inspect_evals_dashboard_schema package

### DIFF
--- a/src/pages/evaluations/template.py
+++ b/src/pages/evaluations/template.py
@@ -3,7 +3,7 @@ import json
 import streamlit as st
 
 # from inspect_evals_scoring.process_log import DashboardLog
-from src.log_utils.dashboard_log import DashboardLog
+from inspect_evals_dashboard_schema import DashboardLog
 from src.log_utils.dashboard_log_utils import get_metrics
 from src.plots.bar import create_bar_chart
 from src.plots.cutoff_scatter import create_cutoff_scatter

--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -1,5 +1,5 @@
 # from inspect_evals_scoring.process_log import DashboardLog
-from src.log_utils.dashboard_log import DashboardLog
+from inspect_evals_dashboard_schema import DashboardLog
 import plotly.graph_objs as go
 import streamlit as st
 from src.log_utils.dashboard_log_utils import dashboard_log_hash_func 

--- a/src/plots/cutoff_scatter.py
+++ b/src/plots/cutoff_scatter.py
@@ -1,5 +1,5 @@
 # from inspect_evals_scoring.process_log import DashboardLog
-from src.log_utils.dashboard_log import DashboardLog
+from inspect_evals_dashboard_schema import DashboardLog
 from src.log_utils.dashboard_log_utils import dashboard_log_hash_func
 from src.plots.plot_utils import create_hover_text
 import pandas as pd

--- a/src/plots/pairwise.py
+++ b/src/plots/pairwise.py
@@ -1,5 +1,5 @@
 # from inspect_evals_scoring.process_log import DashboardLog
-from src.log_utils.dashboard_log import DashboardLog
+from inspect_evals_dashboard_schema import DashboardLog
 import numpy as np
 import pandas as pd
 import streamlit as st

--- a/src/plots/plot_utils.py
+++ b/src/plots/plot_utils.py
@@ -1,6 +1,6 @@
 import pandas as pd
 # from inspect_evals_scoring.process_log import DashboardLog
-from src.log_utils.dashboard_log import DashboardLog
+from inspect_evals_dashboard_schema import DashboardLog
 
 
 def create_hover_text(log: DashboardLog, human_baseline: float = None) -> str:


### PR DESCRIPTION
The commit [4355e80](https://github.com/ArcadiaImpact/inspect_evals_dashboard/pull/1/commits/4355e80aed3530a75910053534ad2e09b21619f2) didn't replace all of the imports. This commit replaces the remaining ones.