### PR TITLE
Slight homepage improvement: deduplicate the heading and use a list for the audience

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,13 +14,16 @@ def home_content():
     
     st.markdown(
         """
-        **Welcome to the Inspect Evals Dashboard - a comprehensive suite for assessing various capabilities of LLMs.**
+        **A comprehensive suite for assessing various capabilities of LLMs**
 
         Inspect Evals is a repository of community-contributed LLM evaluations for Inspect AI. Inspect Evals was created in collaboration by the UK AISI, Arcadia Impact, and the Vector Institute.
         
         This dashboard showcases how well a diverse set of LLMs perform on the evaluations implemented in Inspect Evals. Its main aim is to provide access to this data for downstream use. Our data store is continuously updated with new results as new models and evaluations are published.
 
-        We aim to serve three key audiences: researchers who predict scaling laws and work on the science of evaluations (including those focused on visualization practices); analysts who process model performance data for decision-makers; and technical teams who run internal evaluations against industry benchmarks.
+        We aim to serve three key audiences: 
+        1. researchers who predict scaling laws and work on the science of evaluations (including those focused on visualization practices); 
+        2. analysts who process model performance data for decision-makers; 
+        3. technical teams who run internal evaluations against industry benchmarks.
     """)
 
     titles = ["20 Models", "35 Evals", "127 Tasks"]


### PR DESCRIPTION
# Description

1. Removes duplication in the subtitle: "Welcome to the Inspect Evals Dashboard" is not needed (the name is already in the main heading)
2. It also introduces a list for the audience to make the page more structured and easier to read. I'm not entirely happy with the formatting — I wish streamlit would have tighter list, but I am not looking into updating it. 

##  Screenshots

### After
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/52e9ae47-13b9-4095-8641-6e603f810166" />

### Before

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a8682edd-4a70-4784-95f0-e3c4488432b4" />

