### PR TITLE
Remove yaxis_range TODO

### DIFF
--- a/src/plots/cutoff_scatter.py
+++ b/src/plots/cutoff_scatter.py
@@ -115,8 +115,6 @@ def create_cutoff_scatter(
         title=f"Comparison of {metric} values across models by knowledge cutoff date",
         xaxis_title="Knowledge cutoff date",
         yaxis_title=f"Value of {metric} metric",
-        # TODO: Consider setting yaxis_range between some min and max value
-        # yaxis_range=[0, 1],
         xaxis_tickangle=45,
     )
 


### PR DESCRIPTION
What's the context behind this TODO? Currently streamlit/plotly automatically handles min/max values. This works for all ranges of all possible metrics.

If we set a custom range we risk having our data cut off. I think this makes sense where metrics have a limited domain like accuracy being in [0; 1]. 

But as far as I understand, we can have a wide range of different metrics. Suggestion: remove this TODO.

