### PR TITLE
Fix no human_baseline error

### DIFF
--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -21,9 +21,9 @@ def create_bar_chart(eval_logs: list[DashboardLog], scorer: str, metric: str) ->
         for log in eval_logs
     ]
 
-    # Baseline value (using first model's baseline)
+    # Baseline value - get human_baseline from the first model that has it
     human_baseline = None
-    if eval_logs and eval_logs[0].task_metadata.human_baseline:
+    if eval_logs and getattr(eval_logs[0].task_metadata, 'human_baseline', None):
         human_baseline = eval_logs[0].task_metadata.human_baseline.score
 
     # Create hover text with detailed information

--- a/src/plots/cutoff_scatter.py
+++ b/src/plots/cutoff_scatter.py
@@ -26,7 +26,7 @@ def create_cutoff_scatter(
     """
     # Get human baseline if available, otherwise set to None
     human_baseline = None
-    if eval_logs and eval_logs[0].task_metadata.human_baseline:
+    if eval_logs and getattr(eval_logs[0].task_metadata, 'human_baseline', None):
         human_baseline = eval_logs[0].task_metadata.human_baseline.score
 
     plot_data = []


### PR DESCRIPTION
This fixes the `AttributeError: 'TaskMetadata' object has no attribute 'human_baseline'` when rendering the two affected charts.

I am not 100% sure if it's a proper fix since we have files in two different formats in the config current.
1. I downloaded one of the files (`s3://inspect-evals-dashboard/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json`) and it did have the right field (although as `null`)
2. At the same time (`s3://inspect-evals-dashboard/dev/bbh/openai+gpt-4o-mini/2025-03-17-11-33-27-39fce29d/2025-03-17T11-43-40+00-00_bbh_dAXjNXrPiyyHakCT44WNpt.eval.dashboard.json`) had the data in a different format, where `task_metadata` had an array of `baselines`)
```
    "task_metadata": {
        "baselines": [
            {
                "metric": "accuracy",
                "name": "human",
                "parameters": null,
                "score": 87.5,
                "source": "https://arxiv.org/abs/2210.09261"
            },
            {
                "metric": "accuracy",
                "name": "hf/meta-llama/Llama-3.1-405B",
                "parameters": [
                    "3-shot"
                ],
                "score": 82.9,
                "source": "https://arxiv.org/abs/2412.19437v1"
            },
            ...
          
```

Could we standardise this part of the format? If some of the files is in the older format, could we regenerate them? 