### PR TITLE
Clickable inspect evals logs

### DIFF
--- a/src/pages/evaluations/template.py
+++ b/src/pages/evaluations/template.py
@@ -99,6 +99,9 @@ def render_page(eval_logs: list[DashboardLog], default_values: dict[str, dict[st
         
         fig_bar = create_bar_chart(naive_logs, scorer, metric)
         st.plotly_chart(fig_bar)
+        with st.expander("Inspect Eval logs"):
+            st.markdown(" · ".join([f"<a href='{log.location}'>{log.model_metadata.name}</a>" for log in naive_logs]), unsafe_allow_html=True)
+
 
         fig_cutoff = create_cutoff_scatter(naive_logs, scorer, metric)
         st.plotly_chart(fig_cutoff)

--- a/src/plots/plot_utils.py
+++ b/src/plots/plot_utils.py
@@ -16,7 +16,6 @@ def create_hover_text(log: DashboardLog, human_baseline: float = None) -> str:
         f"Context window size: {log.model_metadata.attributes['context_window_size_tokens']}<br>"
         f"API provider: {log.model_metadata.api_provider}<br>"
         f"API endpoint: {log.model_metadata.api_endpoint}<br>"
-        f"Inspect Logs: <a href='{log.location}'>Link to logs</a><br>"
         f"Cost estimate: {log.cost_estimates['total']:.4f} USD<br>"
         f"Run timestamp: {log.eval.created}<br>"
         f"Human baseline: {human_baseline if human_baseline else 'N/A'}<br>"


### PR DESCRIPTION
# Description

Make inspect eval log links clickable hiding them under the dropdown. 

## Screenshot

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f9fe65e0-aa5b-47e4-a996-2dca88e92b4b" />
