### PR TITLE
Support missing Standard Error in tooltips

### DIFF
--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -39,14 +39,18 @@ def create_bar_chart(
     for log in eval_logs:
         hover_text = create_hover_text(log, human_baseline)
         hover_texts.append(hover_text)
-    
+
     # Hide error bars if all errors are 0
     show_error_bars = any(error != 0 for error in metric_errors)
     error_y = dict(type="data", array=metric_errors, visible=show_error_bars)
 
     hovertemplate = (
         "Score: %{y:.2f}<br>"
-        + ("Standard Error: %{error_y.array:.2f}<br>" if error_y["array"] else "Not computed")
+        + (
+            "Standard Error: %{error_y.array:.2f}<br>"
+            if error_y["array"]
+            else "Not computed"
+        )
         + "%{customdata}<extra></extra>"
     )
 

--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -43,13 +43,15 @@ def create_bar_chart(
     error_y = dict(type="data", array=[metric_errors], visible=True)
 
     # We create hover texts by concatenating plotly patterns with expanded python patterns from create_hover_text().
-    # 
+    #
     # The reason for using two different systems is the following:
     # - plotly data is relatively complex and computed in this function, whereas
     # - create_hover_text() simply lays out constant key-values from nested data
-    hovertemplate = "Score: %{y:.2f}<br>" + \
-        ("Standard Error: %{error_y.array:.2f}<br>" if error_y["array"] else "") + \
-        "%{customdata}<extra></extra>"
+    hovertemplate = (
+        "Score: %{y:.2f}<br>"
+        + ("Standard Error: %{error_y.array:.2f}<br>" if error_y["array"] else "")
+        + "%{customdata}<extra></extra>"
+    )
 
     fig = go.Figure(
         data=[

--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -42,14 +42,13 @@ def create_bar_chart(
 
     # Hide error bars if all errors are 0
     show_error_bars = any(error != 0 for error in metric_errors)
-    error_y = dict(type="data", array=metric_errors, visible=show_error_bars)
 
     hovertemplate = (
         "Score: %{y:.2f}<br>"
         + (
-            "Standard Error: %{error_y.array:.2f}<br>"
-            if error_y["array"]
-            else "Not computed"
+            "Standard Error: %{error_y.array:.4f}<br>"
+            if show_error_bars
+            else "Standard Error: N/A<br>"
         )
         + "%{customdata}<extra></extra>"
     )
@@ -59,10 +58,9 @@ def create_bar_chart(
             go.Bar(
                 x=models,
                 y=metric_values,
-                error_y=error_y,
+                error_y=dict(type="data", array=metric_errors, visible=show_error_bars),
                 name=f"{metric} metric",
                 marker_color="rgba(54, 122, 179, 0.85)",
-                # TODO: Handle missing standard error value
                 hovertemplate=hovertemplate,
                 customdata=hover_texts,
             )

--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -40,16 +40,27 @@ def create_bar_chart(
         hover_text = create_hover_text(log, human_baseline)
         hover_texts.append(hover_text)
 
+    error_y = dict(type="data", array=[metric_errors], visible=True)
+
+    # We create hover texts by concatenating plotly patterns with expanded python patterns from create_hover_text().
+    # 
+    # The reason for using two different systems is the following:
+    # - plotly data is relatively complex and computed in this function, whereas
+    # - create_hover_text() simply lays out constant key-values from nested data
+    hovertemplate = "Score: %{y:.2f}<br>" + \
+        ("Standard Error: %{error_y.array:.2f}<br>" if error_y["array"] else "") + \
+        "%{customdata}<extra></extra>"
+
     fig = go.Figure(
         data=[
             go.Bar(
                 x=models,
                 y=metric_values,
-                error_y=dict(type="data", array=metric_errors, visible=True),
+                error_y=error_y,
                 name=f"{metric} metric",
                 marker_color="rgba(54, 122, 179, 0.85)",
                 # TODO: Handle missing standard error value
-                hovertemplate="Score: %{y:.2f}<br>Standard Error: %{error_y.array:.2f}<br>%{customdata}<extra></extra>",
+                hovertemplate=hovertemplate,
                 customdata=hover_texts,
             )
         ]


### PR DESCRIPTION
I moved out some logic from the `go.Figure` / `go.Bar` call making it conditional. I also added a comment explaining why we use two different systems (hopefully I inferred the reason correctly).