### PR TITLE
Add page for multimodal evals

### DIFF
--- a/app.py
+++ b/app.py
@@ -178,6 +178,9 @@ evals_knowledge = st.Page(
 evals_mathematics = st.Page(
     "src/pages/evaluations/mathematics.py", title="Mathematics", icon="➗"
 )
+evals_multimodal = st.Page(
+    "src/pages/evaluations/multimodal.py", title="Multimodal", icon="👁️"
+)
 evals_reasoning = st.Page(
     "src/pages/evaluations/reasoning.py", title="Reasoning", icon="🧩"
 )
@@ -194,6 +197,7 @@ pg = st.navigation(
             evals_cybersecurity,
             evals_knowledge,
             evals_mathematics,
+            evals_multimodal,
             evals_reasoning,
             evals_safeguards,
         ],

--- a/src/config.py
+++ b/src/config.py
@@ -50,6 +50,7 @@ class EnvironmentConfig(BaseModel):
     cybersecurity: list[EvaluationConfig] = []
     knowledge: list[EvaluationConfig] = []
     mathematics: list[EvaluationConfig] = []
+    multimodal: list[EvaluationConfig] = []
     reasoning: list[EvaluationConfig] = []
     safeguards: list[EvaluationConfig] = []
 

--- a/src/pages/evaluations/multimodal.py
+++ b/src/pages/evaluations/multimodal.py
@@ -1,0 +1,19 @@
+import streamlit as st
+from inspect_evals_dashboard_schema import DashboardLog
+from src.config import EvaluationConfig, load_config
+from src.log_utils.dashboard_log_utils import read_default_values_from_configs
+from src.log_utils.load_eval_logs import get_log_paths, load_evaluation_logs
+from src.pages.evaluations.template import render_page
+
+st.title("Multimodal Evaluations")
+
+st.markdown("""
+            Mathematics evaluations test multimodal capabilities
+            """)
+
+group_config: list[EvaluationConfig] = load_config().multimodal
+default_values: dict[str, dict[str, str]] = read_default_values_from_configs(
+    group_config
+)
+eval_logs: list[DashboardLog] = load_evaluation_logs(get_log_paths(group_config))
+render_page(eval_logs, default_values)

--- a/src/pages/evaluations/multimodal.py
+++ b/src/pages/evaluations/multimodal.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Multimodal Evaluations")
 
 st.markdown("""
-            Mathematics evaluations test multimodal capabilities
+            Multimodal evaluations test the ability to process, understand, and generate content across multiple types of data simultaneously, moving beyond text-only assessments to measure performance with diverse inputs and outputs including images, text, audio, video, and structured data. These evaluations focus on cross-modal understanding, multimodal reasoning, real-world task performance, and robustness across different information types, which is crucial as AI systems increasingly need to operate like humans in environments where information comes in multiple forms rather than just single data streams.
             """)
 
 group_config: list[EvaluationConfig] = load_config().multimodal


### PR DESCRIPTION
Adds a page for multimodal capabilities. Uses 👁️ as an icon. Potentially needs copy.