### PR TITLE
Add sentry support

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@ import os
 import plotly.io as pio  # type: ignore
 import sentry_sdk
 import streamlit as st
-
 from src.config import load_config
 from src.log_utils.load_eval_logs import get_log_paths, load_evaluation_logs
 from src.plots.radar import create_radar_chart

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ plotly==6.0.1
 pyyaml==6.0.2
 requests==2.32.3
 s3fs==2024.12.0
+sentry-sdk==2.24.1
 st-files-connection==0.1.0
 streamlit==1.43.2


### PR DESCRIPTION
This PR add sentry logging. The way it works is a bit hacky — [there is no official support currently, so people found some workarounds](https://github.com/streamlit/streamlit/issues/3426) and this PR uses one of them. 

Based on cursory testing it seems to work reliably. The biggest danger is something breaking when updating streamlit to a newer version. 


## Screenshot

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/ff0187b9-e952-40ca-8134-4aba170d8a17" />
