### PR TITLE
Consistently align hover labels to the left

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import plotly.io as pio
 import streamlit as st
 from src.config import load_config
 from src.log_utils.load_eval_logs import get_log_paths, load_evaluation_logs
@@ -8,6 +9,10 @@ def home_content():
     st.set_page_config(
         page_title="Inspect Evals Dashboard", page_icon="🤖", layout="centered"
     )
+
+    template = pio.templates[pio.templates.default]
+    template.layout.hoverlabel.align = "left"
+    pio.templates.default = template
 
     # Global styles
     st.markdown(

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-import plotly.io as pio
+import plotly.io as pio  # type: ignore
 import streamlit as st
 from src.config import load_config
 from src.log_utils.load_eval_logs import get_log_paths, load_evaluation_logs


### PR DESCRIPTION
# Description

This PR fixes an issue with tooltips being inconsistently aligned when they are close to the right side of the chart. This change makes labels easier to read. 

# Screenshots

## Before
<img width="757" alt="image" src="https://github.com/user-attachments/assets/f008cd53-3a15-45f6-8e0f-f7dfc3c96879" />


## After

<img width="750" alt="image" src="https://github.com/user-attachments/assets/110737ff-c693-4a43-970e-21c3470b0a51" />

