### PR TITLE
A script for updating the config from s3 path

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,559 +4,724 @@
 prod:
   evaluations:
     agents:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     assistants:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     coding:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     cybersecurity:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     knowledge:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     mathematics:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     multimodal:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     reasoning:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
     safeguards:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
-          - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
-
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/1.json
+      - s3://$AWS_S3_BUCKET/dev/pubmedqa/2.json
 stage:
   evaluations:
     agents:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: piqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: piqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     assistants:
-      - name: piqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
+    - name: piqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     coding:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: humaneval
-        default_scorer: verify
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-small-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_2jD3BjMKgrLy4ypQQKP4d6.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o-mini/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_JpJPXJe6Gpch8ZM7NHZCkP.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BX4KUbpBhuoADZmpH6owkQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_W5SF5vQurmkdqNw4PAA8ip.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
-      - name: mbpp
-        default_scorer: verify
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/google+gemini-2.0-flash-001/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_cXX443dkR6fqgYQMs6w7mt.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/grok+grok-2-1212/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_dAXopDmumnZVxmGnpkZtWY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-large-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HHC872Q5wsUsMD7oEmfGCF.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-small-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_EshFNEhCuHP9PTyubAKUXj.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o-mini/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_azWKogmyB9rt4T9s9n6agE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_TZR75z8SQ9yEa6tFzmPcJB.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+deepseek+deepseek-chat/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_WVYEwCbgNZ5xvndxm7iNjx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HYYC2e4c8mkJjRR4R4Gt7A.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_8bYFtzvuAFuHWXiYcgUVaY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+mistralai+codestral-2501/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_6QrPaBwjhk7UoeAKFr7gUz.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: humaneval
+      default_scorer: verify
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-small-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_2jD3BjMKgrLy4ypQQKP4d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o-mini/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_JpJPXJe6Gpch8ZM7NHZCkP.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BX4KUbpBhuoADZmpH6owkQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_W5SF5vQurmkdqNw4PAA8ip.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
+    - name: mbpp
+      default_scorer: verify
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/google+gemini-2.0-flash-001/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_cXX443dkR6fqgYQMs6w7mt.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/grok+grok-2-1212/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_dAXopDmumnZVxmGnpkZtWY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-large-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HHC872Q5wsUsMD7oEmfGCF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-small-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_EshFNEhCuHP9PTyubAKUXj.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o-mini/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_azWKogmyB9rt4T9s9n6agE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_TZR75z8SQ9yEa6tFzmPcJB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+deepseek+deepseek-chat/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_WVYEwCbgNZ5xvndxm7iNjx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HYYC2e4c8mkJjRR4R4Gt7A.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_8bYFtzvuAFuHWXiYcgUVaY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+mistralai+codestral-2501/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_6QrPaBwjhk7UoeAKFr7gUz.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
     cybersecurity:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: cyse2_vulnerability_exploit
-        default_scorer: vul_exploit_scorer
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_es5rykBhvBh7LQEkD9odr2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_ffd6EHnLjPqUDRKSFVtj8z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-00-1eeb12e2/2025-03-21T02-55-43+00-00_cyse2-vulnerability-exploit_3bne2adFSr955MuvyPryyn.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_BaXqmhGJo2JiDyXbQBdbzx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_DhGNnJVdkQe8Tajdaw92hk.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_aALAYGE9AFZfLxHetikj84.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_eCFE3u2o6AQqJxwckoCudK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_FeZkiNkpbo9KZDzMHdeDFc.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-00-1eeb12e2/2025-03-21T12-21-31+00-00_cyse2-vulnerability-exploit_YsncuMa4ehJiQqXqfbLT63.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-05-29ccb3c5/2025-03-22T01-52-35+00-00_cyse2-vulnerability-exploit_XMk7LCPBeRRsKEzrfykRhX.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-00-1eeb12e2/2025-03-21T10-55-12+00-00_cyse2-vulnerability-exploit_6h3cVKygL5KTVpRUbVWsSe.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-05-29ccb3c5/2025-03-21T04-35-59+00-00_cyse2-vulnerability-exploit_YjTQHqYdQ3s5JZ26GJLHfT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-00-1eeb12e2/2025-03-21T02-55-43+00-00_cyse2-vulnerability-exploit_7MDTnmx2B9T2qAXJgH8c36.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_SHMaBhxQTwJWNMjBwcGXam.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_SCSk8u8zyaCaYbxbacWPQq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_L7vkTkgeKaTANuv5LVRFJT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-00-1eeb12e2/2025-03-21T12-02-58+00-00_cyse2-vulnerability-exploit_TPEibiypdu9YbqHzptNnCV.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_LusC322dG3ZczjzMH7T6nv.eval.dashboard.json
-      - name: cyse2_interpreter_abuse
-        default_scorer: model_graded_qa
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_E7k8gvuMUUAeSymqoeEdt8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/grok+grok-2-1212/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FCkDomKf4YKNtZ5GfhurWp.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-large-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_DjkpwVeFAGhBDidJxgnqYy.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-small-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LVmanS8A6QG39LWHrBW9RG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o-mini/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_g4SQAvB5vr9MGTHfSo4BRb.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_a69JteEPijmGC33tc494FT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FKK5t4HwduW26GZ6nQUSsQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LqbyPWL7EUzGSm4RkGdPQm.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: cyse2_interpreter_abuse
+      default_scorer: model_graded_qa
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_E7k8gvuMUUAeSymqoeEdt8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/grok+grok-2-1212/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FCkDomKf4YKNtZ5GfhurWp.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-large-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_DjkpwVeFAGhBDidJxgnqYy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-small-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LVmanS8A6QG39LWHrBW9RG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o-mini/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_g4SQAvB5vr9MGTHfSo4BRb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_a69JteEPijmGC33tc494FT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FKK5t4HwduW26GZ6nQUSsQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LqbyPWL7EUzGSm4RkGdPQm.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
+    - name: cyse2_prompt_injection
+      default_scorer: model_graded_qa
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_9WWRwhgwiheavh8efxNcdQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/grok+grok-2-1212/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_Yw3aeSvjRCRmDXTcbrJ8uw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/mistral+mistral-large-latest/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_khZYiDQirtQUETnzPaCJWT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/mistral+mistral-small-latest/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_JbzL6uqp5ZKVoJP3J8P4YN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openai+gpt-4o-mini/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_RXLhCF2TLg72KdeEToVrnu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openai+gpt-4o/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_2eeLDDr5TyJPbVZtzi3b2i.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+deepseek+deepseek-chat/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_FnEGjXgm9zMoSxPSRZoKfM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_Y2oSi4qFDHz6RzAJAVkzjZ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_EadR3zXRHyFB74MswCdVM4.eval.dashboard.json
+    - name: cyse2_vulnerability_exploit
+      default_scorer: vul_exploit_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_ffd6EHnLjPqUDRKSFVtj8z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_BaXqmhGJo2JiDyXbQBdbzx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_aALAYGE9AFZfLxHetikj84.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_FeZkiNkpbo9KZDzMHdeDFc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-05-29ccb3c5/2025-03-22T01-52-35+00-00_cyse2-vulnerability-exploit_XMk7LCPBeRRsKEzrfykRhX.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-05-29ccb3c5/2025-03-21T04-35-59+00-00_cyse2-vulnerability-exploit_YjTQHqYdQ3s5JZ26GJLHfT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_SHMaBhxQTwJWNMjBwcGXam.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_L7vkTkgeKaTANuv5LVRFJT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_LusC322dG3ZczjzMH7T6nv.eval.dashboard.json
     knowledge:
-      - name: commonsense_qa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/grok+grok-2-1212/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_9v5evKgxYH2kisaeoaNRTU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-large-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_SW54bJvzqdYT36NqQzHCk9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-small-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_WHSVGyMyrTyqaYA62xLcav.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o-mini/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_fP6UWXs4f7q6E77ygw5zEZ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_28ydCrCvnZZrWWKv5ZyXrQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_hkZ3BNeXAFXMLbuAgLx5d8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_FaiNNoD4u8EN7twkMbr9Gj.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_3vJwE788kocZPWM5cwBBui.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T06-43-11+00-00_commonsense-qa_FMojf23SX93e4VXYfYrmC5.eval.dashboard.json
-      - name: gpqa_diamond
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-large-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_FhjFWidQhK2eQ8spQUZs5f.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-small-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_BE3ZgPnMGurkT9aVabmbFz.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o-mini/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_hCSqBXY8dMBk4hqkHsYsTK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_KYWXfnirrr9GFu3LgrG8Qx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+deepseek+deepseek-chat/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_REXYstCD24LTXyGsPLhqwH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_k3AVnJnFBuAV4jwwqAkb7h.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-20T06-11-35+00-00_gpqa-diamond_ZRMaspJfbUxa5GTkQe526o.eval.dashboard.json
+    - name: commonsense_qa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/grok+grok-2-1212/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_9v5evKgxYH2kisaeoaNRTU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-large-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_SW54bJvzqdYT36NqQzHCk9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-small-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_WHSVGyMyrTyqaYA62xLcav.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o-mini/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_fP6UWXs4f7q6E77ygw5zEZ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_28ydCrCvnZZrWWKv5ZyXrQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_hkZ3BNeXAFXMLbuAgLx5d8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_FaiNNoD4u8EN7twkMbr9Gj.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_3vJwE788kocZPWM5cwBBui.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T06-43-11+00-00_commonsense-qa_FMojf23SX93e4VXYfYrmC5.eval.dashboard.json
+    - name: gpqa_diamond
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-large-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_FhjFWidQhK2eQ8spQUZs5f.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-small-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_BE3ZgPnMGurkT9aVabmbFz.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o-mini/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_hCSqBXY8dMBk4hqkHsYsTK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_KYWXfnirrr9GFu3LgrG8Qx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+deepseek+deepseek-chat/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_REXYstCD24LTXyGsPLhqwH.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_k3AVnJnFBuAV4jwwqAkb7h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-20T06-11-35+00-00_gpqa-diamond_ZRMaspJfbUxa5GTkQe526o.eval.dashboard.json
+    - name: mmlu_pro
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-large-latest/2025-03-20-12-48-43-c03ecf66/2025-03-20T13-15-51+00-00_mmlu-pro_e6rkvFpTfqeCkmqDxTRw6F.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-small-latest/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_hanjachaAvYpLvxn4DHTbF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_M7uEBH5D9kGTcBskoAY4gV.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_EhcDf4Wf8Gm7EeW2xZ6Km9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o1-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_WnLxKdZNhfk4g93WAKMwoN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o3-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_FJESccDWrQr4H9sBzWjYU6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+deepseek+deepseek-chat/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_7vYtuAjLAzPcCn5eKBPtjK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_WTRJmiyXh67zVWkJAdHRUb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_LNoD7YebCiKBwdDDQCFsjY.eval.dashboard.json
     mathematics:
-      - name: gsm8k
-        default_scorer: match
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-large-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_UVCC2jzJ7Tzdx9utopctFn.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-small-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_oGYtVysKrr3THnnd4Dv7cu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o-mini/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_Yqb2W9tGQveuNxMJbREdhk.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_RkFTQodnGh7eYyCDm7UP6a.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+deepseek+deepseek-chat/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_4doXVuP4qHiMeayWBENZqf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_fYRSsWdrTN3PRa6toYQskf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_8sm4vz6Mi3VW6sSm3HVLck.eval.dashboard.json
+    - name: gsm8k
+      default_scorer: match
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-large-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_UVCC2jzJ7Tzdx9utopctFn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-small-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_oGYtVysKrr3THnnd4Dv7cu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o-mini/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_Yqb2W9tGQveuNxMJbREdhk.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_RkFTQodnGh7eYyCDm7UP6a.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+deepseek+deepseek-chat/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_4doXVuP4qHiMeayWBENZqf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_fYRSsWdrTN3PRa6toYQskf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_8sm4vz6Mi3VW6sSm3HVLck.eval.dashboard.json
+    - name: mathvista
+      default_scorer: mathvista_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/anthropic+claude-3-7-sonnet-20250219/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_hHHGAfshkqqkCqhjzfbixC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/mistral+mistral-small-latest/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_eNm3nBb5AUmC9LcDEotSpC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o-mini/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_m5vWYZr7bgzFtgret5BXcn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_2CzG6oJwc3uHXNvyjiwrSf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+deepseek+deepseek-chat/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_jm2DzogBjSoFu8LHPeQd4j.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_RnYW59YPBh7vDh4ZD3Rhx4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_aojPnRir2f4JRobhLqLgA9.eval.dashboard.json
     multimodal:
-      - name: mmmu_open
-        default_scorer: model_graded_fact
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
+    - name: mathvista
+      default_scorer: mathvista_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/anthropic+claude-3-7-sonnet-20250219/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_hHHGAfshkqqkCqhjzfbixC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/mistral+mistral-small-latest/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_eNm3nBb5AUmC9LcDEotSpC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o-mini/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_m5vWYZr7bgzFtgret5BXcn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_2CzG6oJwc3uHXNvyjiwrSf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+deepseek+deepseek-chat/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_jm2DzogBjSoFu8LHPeQd4j.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_RnYW59YPBh7vDh4ZD3Rhx4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_aojPnRir2f4JRobhLqLgA9.eval.dashboard.json
+    - name: mmmu_multiple_choice
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/mistral+mistral-small-latest/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T13-14-44+00-00_mmmu-multiple-choice_82fX75CnQT8cYarx2GUEgv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_KecRXQTPCHeDmhVucnQCsE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_QkEnqrGpgg9pbgUfz7f9d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+o1-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_WYVgRVDJwefG2of2bLdFQv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-chat/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Pu4wQquRtRUjjShnLLgd6h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-r1/2025-03-20-13-01-03-7c3c3eaf/2025-03-23T04-10-27+00-00_mmmu-multiple-choice_7DCgBa4fykTv9MaUCfRDcB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Emg5DATRZUWVSCoLkjpzXr.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_YJ25aAF3PBLurAPW7pzwXW.eval.dashboard.json
+    - name: mmmu_open
+      default_scorer: model_graded_fact
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
     reasoning:
-      - name: bbh
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_RxchDcsLppFHA6kuwuoL83.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/grok+grok-2-1212/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_7JZNhgQ7FMMWntRAehbxd8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-large-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XiMwuidzJjNRGBS8mXPXrW.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-small-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AaNsDsCU5ugYaqCRzsLLuR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o-mini/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AkBF6Ze93sPLZdmaxeXbDX.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_49YhWkhkFcFtfCn37QQqqo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o1-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_DbxAEA7wvfePoAddRcza57.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o3-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_LYiUYn24dFUB6YDXUwwBCR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-chat/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XisL3dpLtjBf9zWcWxjYrg.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-r1/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-46-14+00-00_bbh_bU42pEgKVLkSzdpqvx33cG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_Gh8QAFG2USJs2mEZx4tGkY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_jTfpLYU3TvLfeCLbi4GdZu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_i4SuZzVUiusyZAPTxeXbCQ.eval.dashboard.json
-      - name: hellaswag
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-large-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_49kvsSCpeFH9eyTFoGQTpR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-small-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_am6gMWif3hjqbftHZhLxeU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o-mini/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_UPtLEiYzxnrk6x6o8KXFWG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_b5kiBjmiJf99RxmCd7kVcc.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-21-467ef46a/2025-03-19T12-59-50+00-00_hellaswag_5jhMUpwnaNAwRmVpumSQ8y.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_mr2625xZk54gFhkAjFoC82.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_TEAke8jfAHbzSNxS7gRVei.eval.dashboard.json
-      - name: ifeval
-        default_scorer: instruction_following
-        default_metric: final_acc
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
+    - name: bbh
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_RxchDcsLppFHA6kuwuoL83.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/grok+grok-2-1212/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_7JZNhgQ7FMMWntRAehbxd8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-large-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XiMwuidzJjNRGBS8mXPXrW.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-small-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AaNsDsCU5ugYaqCRzsLLuR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o-mini/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AkBF6Ze93sPLZdmaxeXbDX.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_49YhWkhkFcFtfCn37QQqqo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o1-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_DbxAEA7wvfePoAddRcza57.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o3-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_LYiUYn24dFUB6YDXUwwBCR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-chat/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XisL3dpLtjBf9zWcWxjYrg.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-r1/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-46-14+00-00_bbh_bU42pEgKVLkSzdpqvx33cG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_Gh8QAFG2USJs2mEZx4tGkY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_jTfpLYU3TvLfeCLbi4GdZu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_i4SuZzVUiusyZAPTxeXbCQ.eval.dashboard.json
+    - name: hellaswag
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-large-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_49kvsSCpeFH9eyTFoGQTpR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-small-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_am6gMWif3hjqbftHZhLxeU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o-mini/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_UPtLEiYzxnrk6x6o8KXFWG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_b5kiBjmiJf99RxmCd7kVcc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-21-467ef46a/2025-03-19T12-59-50+00-00_hellaswag_5jhMUpwnaNAwRmVpumSQ8y.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_mr2625xZk54gFhkAjFoC82.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_TEAke8jfAHbzSNxS7gRVei.eval.dashboard.json
+    - name: ifeval
+      default_scorer: instruction_following
+      default_metric: final_acc
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
+    - name: mmlu_pro
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-large-latest/2025-03-20-12-48-43-c03ecf66/2025-03-20T13-15-51+00-00_mmlu-pro_e6rkvFpTfqeCkmqDxTRw6F.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-small-latest/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_hanjachaAvYpLvxn4DHTbF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_M7uEBH5D9kGTcBskoAY4gV.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_EhcDf4Wf8Gm7EeW2xZ6Km9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o1-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_WnLxKdZNhfk4g93WAKMwoN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o3-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_FJESccDWrQr4H9sBzWjYU6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+deepseek+deepseek-chat/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_7vYtuAjLAzPcCn5eKBPtjK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_WTRJmiyXh67zVWkJAdHRUb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_LNoD7YebCiKBwdDDQCFsjY.eval.dashboard.json
+    - name: mmmu_multiple_choice
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/mistral+mistral-small-latest/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T13-14-44+00-00_mmmu-multiple-choice_82fX75CnQT8cYarx2GUEgv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_KecRXQTPCHeDmhVucnQCsE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_QkEnqrGpgg9pbgUfz7f9d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+o1-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_WYVgRVDJwefG2of2bLdFQv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-chat/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Pu4wQquRtRUjjShnLLgd6h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-r1/2025-03-20-13-01-03-7c3c3eaf/2025-03-23T04-10-27+00-00_mmmu-multiple-choice_7DCgBa4fykTv9MaUCfRDcB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Emg5DATRZUWVSCoLkjpzXr.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_YJ25aAF3PBLurAPW7pzwXW.eval.dashboard.json
+    - name: mmmu_open
+      default_scorer: model_graded_fact
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
     safeguards:
-      # Temporarily using ifeval for safeguards until agentharm is available
-      - name: ifeval
-        default_scorer: instruction_following
-        default_metric: final_acc
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
-
+    - name: agentharm
+      default_scorer: combined_scorer
+      default_metric: avg_score
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/anthropic+claude-3-7-sonnet-20250219/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_Yj8XiXuBk4897LVyYQJycc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/google+gemini-2.0-flash-001/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_fMtKw9EAe2bt2YSTKkiW6Y.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openai+gpt-4o-mini/2025-03-24-00-42-50-52d71604/2025-03-24T02-54-38+00-00_agentharm_Bb8NyyTVMxBtiFEnbFQg8h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openai+gpt-4o/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_Rjoac8n7hPaGwt44bxLaTQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openrouter+deepseek+deepseek-chat/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_ABwHhTekcokE4Yc6Qscpaf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-24-00-42-50-52d71604/2025-03-24T02-54-38+00-00_agentharm_RC3GekdRpikexrfMV3B3Tq.eval.dashboard.json
 dev:
   evaluations:
     agents:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: piqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: piqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     assistants:
-      - name: piqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
+    - name: piqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_SAkKS5qqUCFTJpUFtju9Qv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/grok+grok-2-1212/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_n7cKGDhYHHg4bJ77qDcnhK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-large-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_2hGzgjhFmfwyk8EHvY8d9m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/mistral+mistral-small-latest/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_oRkBtSUu53Pxi8frWBTb2Z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o-mini/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_KcHLZGrDWf2CJXGsnt9wGi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openai+gpt-4o/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_MQyJ3Vn5Cr8pwszwrXUUWM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+deepseek+deepseek-chat/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_7nGsLMWLX5jqs63UdxFmic.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_PShCuKcmFwwtHRhSp4DxeK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     coding:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: humaneval
-        default_scorer: verify
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-small-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_2jD3BjMKgrLy4ypQQKP4d6.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o-mini/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_JpJPXJe6Gpch8ZM7NHZCkP.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BX4KUbpBhuoADZmpH6owkQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_W5SF5vQurmkdqNw4PAA8ip.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
-      - name: mbpp
-        default_scorer: verify
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/google+gemini-2.0-flash-001/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_cXX443dkR6fqgYQMs6w7mt.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/grok+grok-2-1212/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_dAXopDmumnZVxmGnpkZtWY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-large-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HHC872Q5wsUsMD7oEmfGCF.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-small-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_EshFNEhCuHP9PTyubAKUXj.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o-mini/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_azWKogmyB9rt4T9s9n6agE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_TZR75z8SQ9yEa6tFzmPcJB.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+deepseek+deepseek-chat/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_WVYEwCbgNZ5xvndxm7iNjx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HYYC2e4c8mkJjRR4R4Gt7A.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_8bYFtzvuAFuHWXiYcgUVaY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+mistralai+codestral-2501/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_6QrPaBwjhk7UoeAKFr7gUz.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: humaneval
+      default_scorer: verify
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-small-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_2jD3BjMKgrLy4ypQQKP4d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o-mini/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_JpJPXJe6Gpch8ZM7NHZCkP.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openai+gpt-4o/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BX4KUbpBhuoADZmpH6owkQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_W5SF5vQurmkdqNw4PAA8ip.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
+    - name: mbpp
+      default_scorer: verify
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/google+gemini-2.0-flash-001/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_cXX443dkR6fqgYQMs6w7mt.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/grok+grok-2-1212/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_dAXopDmumnZVxmGnpkZtWY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-large-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HHC872Q5wsUsMD7oEmfGCF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/mistral+mistral-small-latest/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_EshFNEhCuHP9PTyubAKUXj.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o-mini/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_azWKogmyB9rt4T9s9n6agE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openai+gpt-4o/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_TZR75z8SQ9yEa6tFzmPcJB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+deepseek+deepseek-chat/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_WVYEwCbgNZ5xvndxm7iNjx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_HYYC2e4c8mkJjRR4R4Gt7A.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_8bYFtzvuAFuHWXiYcgUVaY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+mistralai+codestral-2501/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_6QrPaBwjhk7UoeAKFr7gUz.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
     cybersecurity:
-      - name: cybench
-        default_scorer: includes
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
-      - name: cyse2_vulnerability_exploit
-        default_scorer: vul_exploit_scorer
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_es5rykBhvBh7LQEkD9odr2.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_ffd6EHnLjPqUDRKSFVtj8z.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-00-1eeb12e2/2025-03-21T02-55-43+00-00_cyse2-vulnerability-exploit_3bne2adFSr955MuvyPryyn.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_BaXqmhGJo2JiDyXbQBdbzx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_DhGNnJVdkQe8Tajdaw92hk.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_aALAYGE9AFZfLxHetikj84.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_eCFE3u2o6AQqJxwckoCudK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_FeZkiNkpbo9KZDzMHdeDFc.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-00-1eeb12e2/2025-03-21T12-21-31+00-00_cyse2-vulnerability-exploit_YsncuMa4ehJiQqXqfbLT63.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-05-29ccb3c5/2025-03-22T01-52-35+00-00_cyse2-vulnerability-exploit_XMk7LCPBeRRsKEzrfykRhX.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-00-1eeb12e2/2025-03-21T10-55-12+00-00_cyse2-vulnerability-exploit_6h3cVKygL5KTVpRUbVWsSe.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-05-29ccb3c5/2025-03-21T04-35-59+00-00_cyse2-vulnerability-exploit_YjTQHqYdQ3s5JZ26GJLHfT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-00-1eeb12e2/2025-03-21T02-55-43+00-00_cyse2-vulnerability-exploit_7MDTnmx2B9T2qAXJgH8c36.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_SHMaBhxQTwJWNMjBwcGXam.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-00-1eeb12e2/2025-03-21T05-07-40+00-00_cyse2-vulnerability-exploit_SCSk8u8zyaCaYbxbacWPQq.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_L7vkTkgeKaTANuv5LVRFJT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-00-1eeb12e2/2025-03-21T12-02-58+00-00_cyse2-vulnerability-exploit_TPEibiypdu9YbqHzptNnCV.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_LusC322dG3ZczjzMH7T6nv.eval.dashboard.json
-      - name: cyse2_interpreter_abuse
-        default_scorer: model_graded_qa
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_E7k8gvuMUUAeSymqoeEdt8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/grok+grok-2-1212/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FCkDomKf4YKNtZ5GfhurWp.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-large-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_DjkpwVeFAGhBDidJxgnqYy.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-small-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LVmanS8A6QG39LWHrBW9RG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o-mini/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_g4SQAvB5vr9MGTHfSo4BRb.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_a69JteEPijmGC33tc494FT.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FKK5t4HwduW26GZ6nQUSsQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LqbyPWL7EUzGSm4RkGdPQm.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
+    - name: cybench
+      default_scorer: includes
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/grok+grok-2-1212/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_DAkzdBTyxXZjSvXQzxzLPo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-large-latest/2025-03-21-02-07-44-c64b7513/2025-03-21T11-05-18+00-00_cybench_ReM873qCpNqtdutBP9FcNf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/mistral+mistral-small-latest/2025-03-21-02-07-44-c64b7513/2025-03-22T02-18-09+00-00_cybench_DzBHWdrryWrADyCf69jFL9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o-mini/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_aiNcJNLKRCVx3mhrqX34eq.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openai+gpt-4o/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_SEmqQZG2r2HhNWEKyQEYN2.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
+    - name: cyse2_interpreter_abuse
+      default_scorer: model_graded_qa
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_E7k8gvuMUUAeSymqoeEdt8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/grok+grok-2-1212/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FCkDomKf4YKNtZ5GfhurWp.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-large-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_DjkpwVeFAGhBDidJxgnqYy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/mistral+mistral-small-latest/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LVmanS8A6QG39LWHrBW9RG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o-mini/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_g4SQAvB5vr9MGTHfSo4BRb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openai+gpt-4o/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_a69JteEPijmGC33tc494FT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_FKK5t4HwduW26GZ6nQUSsQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_LqbyPWL7EUzGSm4RkGdPQm.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
+    - name: cyse2_prompt_injection
+      default_scorer: model_graded_qa
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_9WWRwhgwiheavh8efxNcdQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/grok+grok-2-1212/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_Yw3aeSvjRCRmDXTcbrJ8uw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/mistral+mistral-large-latest/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_khZYiDQirtQUETnzPaCJWT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/mistral+mistral-small-latest/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_JbzL6uqp5ZKVoJP3J8P4YN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openai+gpt-4o-mini/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_RXLhCF2TLg72KdeEToVrnu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openai+gpt-4o/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_2eeLDDr5TyJPbVZtzi3b2i.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+deepseek+deepseek-chat/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_FnEGjXgm9zMoSxPSRZoKfM.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_Y2oSi4qFDHz6RzAJAVkzjZ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_prompt_injection/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-05-47-740a63ba/2025-03-22T12-07-45+00-00_cyse2-prompt-injection_EadR3zXRHyFB74MswCdVM4.eval.dashboard.json
+    - name: cyse2_vulnerability_exploit
+      default_scorer: vul_exploit_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_ffd6EHnLjPqUDRKSFVtj8z.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/grok+grok-2-1212/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_BaXqmhGJo2JiDyXbQBdbzx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-large-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_aALAYGE9AFZfLxHetikj84.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/mistral+mistral-small-latest/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_FeZkiNkpbo9KZDzMHdeDFc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o-mini/2025-03-21-02-08-05-29ccb3c5/2025-03-22T01-52-35+00-00_cyse2-vulnerability-exploit_XMk7LCPBeRRsKEzrfykRhX.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openai+gpt-4o/2025-03-21-02-08-05-29ccb3c5/2025-03-21T04-35-59+00-00_cyse2-vulnerability-exploit_YjTQHqYdQ3s5JZ26GJLHfT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+deepseek+deepseek-chat/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_SHMaBhxQTwJWNMjBwcGXam.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T10-56-10+00-00_cyse2-vulnerability-exploit_L7vkTkgeKaTANuv5LVRFJT.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/cyse2_vulnerability_exploit/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-08-05-29ccb3c5/2025-03-21T03-10-58+00-00_cyse2-vulnerability-exploit_LusC322dG3ZczjzMH7T6nv.eval.dashboard.json
     knowledge:
-      - name: commonsense_qa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/grok+grok-2-1212/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_9v5evKgxYH2kisaeoaNRTU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-large-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_SW54bJvzqdYT36NqQzHCk9.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-small-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_WHSVGyMyrTyqaYA62xLcav.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o-mini/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_fP6UWXs4f7q6E77ygw5zEZ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_28ydCrCvnZZrWWKv5ZyXrQ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_hkZ3BNeXAFXMLbuAgLx5d8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_FaiNNoD4u8EN7twkMbr9Gj.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_3vJwE788kocZPWM5cwBBui.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T06-43-11+00-00_commonsense-qa_FMojf23SX93e4VXYfYrmC5.eval.dashboard.json
-      - name: gpqa_diamond
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-large-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_FhjFWidQhK2eQ8spQUZs5f.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-small-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_BE3ZgPnMGurkT9aVabmbFz.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o-mini/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_hCSqBXY8dMBk4hqkHsYsTK.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_KYWXfnirrr9GFu3LgrG8Qx.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+deepseek+deepseek-chat/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_REXYstCD24LTXyGsPLhqwH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_k3AVnJnFBuAV4jwwqAkb7h.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-20T06-11-35+00-00_gpqa-diamond_ZRMaspJfbUxa5GTkQe526o.eval.dashboard.json
+    - name: commonsense_qa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/grok+grok-2-1212/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_9v5evKgxYH2kisaeoaNRTU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-large-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_SW54bJvzqdYT36NqQzHCk9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/mistral+mistral-small-latest/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_WHSVGyMyrTyqaYA62xLcav.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o-mini/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_fP6UWXs4f7q6E77ygw5zEZ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openai+gpt-4o/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_28ydCrCvnZZrWWKv5ZyXrQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_hkZ3BNeXAFXMLbuAgLx5d8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_FaiNNoD4u8EN7twkMbr9Gj.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T03-53-47+00-00_commonsense-qa_3vJwE788kocZPWM5cwBBui.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-51-07-1110860b/2025-03-19T06-43-11+00-00_commonsense-qa_FMojf23SX93e4VXYfYrmC5.eval.dashboard.json
+    - name: gpqa_diamond
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-large-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_FhjFWidQhK2eQ8spQUZs5f.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/mistral+mistral-small-latest/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_BE3ZgPnMGurkT9aVabmbFz.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o-mini/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_hCSqBXY8dMBk4hqkHsYsTK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openai+gpt-4o/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_KYWXfnirrr9GFu3LgrG8Qx.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+deepseek+deepseek-chat/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_REXYstCD24LTXyGsPLhqwH.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-19T22-56-28+00-00_gpqa-diamond_k3AVnJnFBuAV4jwwqAkb7h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gpqa_diamond/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-22-52-04-c43dcb63/2025-03-20T06-11-35+00-00_gpqa-diamond_ZRMaspJfbUxa5GTkQe526o.eval.dashboard.json
+    - name: mmlu_pro
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-large-latest/2025-03-20-12-48-43-c03ecf66/2025-03-20T13-15-51+00-00_mmlu-pro_e6rkvFpTfqeCkmqDxTRw6F.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-small-latest/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_hanjachaAvYpLvxn4DHTbF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_M7uEBH5D9kGTcBskoAY4gV.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_EhcDf4Wf8Gm7EeW2xZ6Km9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o1-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_WnLxKdZNhfk4g93WAKMwoN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o3-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_FJESccDWrQr4H9sBzWjYU6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+deepseek+deepseek-chat/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_7vYtuAjLAzPcCn5eKBPtjK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_WTRJmiyXh67zVWkJAdHRUb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_LNoD7YebCiKBwdDDQCFsjY.eval.dashboard.json
     mathematics:
-      - name: gsm8k
-        default_scorer: match
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-large-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_UVCC2jzJ7Tzdx9utopctFn.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-small-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_oGYtVysKrr3THnnd4Dv7cu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o-mini/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_Yqb2W9tGQveuNxMJbREdhk.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_RkFTQodnGh7eYyCDm7UP6a.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+deepseek+deepseek-chat/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_4doXVuP4qHiMeayWBENZqf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_fYRSsWdrTN3PRa6toYQskf.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_8sm4vz6Mi3VW6sSm3HVLck.eval.dashboard.json
+    - name: gsm8k
+      default_scorer: match
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-large-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_UVCC2jzJ7Tzdx9utopctFn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/mistral+mistral-small-latest/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_oGYtVysKrr3THnnd4Dv7cu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o-mini/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_Yqb2W9tGQveuNxMJbREdhk.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openai+gpt-4o/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_RkFTQodnGh7eYyCDm7UP6a.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+deepseek+deepseek-chat/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_4doXVuP4qHiMeayWBENZqf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_fYRSsWdrTN3PRa6toYQskf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/gsm8k/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-11-19-21-f0368014/2025-03-19T11-22-04+00-00_gsm8k_8sm4vz6Mi3VW6sSm3HVLck.eval.dashboard.json
+    - name: mathvista
+      default_scorer: mathvista_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/anthropic+claude-3-7-sonnet-20250219/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_hHHGAfshkqqkCqhjzfbixC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/mistral+mistral-small-latest/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_eNm3nBb5AUmC9LcDEotSpC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o-mini/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_m5vWYZr7bgzFtgret5BXcn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_2CzG6oJwc3uHXNvyjiwrSf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+deepseek+deepseek-chat/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_jm2DzogBjSoFu8LHPeQd4j.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_RnYW59YPBh7vDh4ZD3Rhx4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_aojPnRir2f4JRobhLqLgA9.eval.dashboard.json
     multimodal:
-      - name: mmmu_open
-        default_scorer: model_graded_fact
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
+    - name: mathvista
+      default_scorer: mathvista_scorer
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/anthropic+claude-3-7-sonnet-20250219/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_hHHGAfshkqqkCqhjzfbixC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/mistral+mistral-small-latest/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_eNm3nBb5AUmC9LcDEotSpC.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o-mini/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_m5vWYZr7bgzFtgret5BXcn.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openai+gpt-4o/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_2CzG6oJwc3uHXNvyjiwrSf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+deepseek+deepseek-chat/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_jm2DzogBjSoFu8LHPeQd4j.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_RnYW59YPBh7vDh4ZD3Rhx4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mathvista/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-11-54-22-2d7b6f17/2025-03-22T11-55-28+00-00_mathvista_aojPnRir2f4JRobhLqLgA9.eval.dashboard.json
+    - name: mmmu_multiple_choice
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/mistral+mistral-small-latest/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T13-14-44+00-00_mmmu-multiple-choice_82fX75CnQT8cYarx2GUEgv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_KecRXQTPCHeDmhVucnQCsE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_QkEnqrGpgg9pbgUfz7f9d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+o1-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_WYVgRVDJwefG2of2bLdFQv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-chat/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Pu4wQquRtRUjjShnLLgd6h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-r1/2025-03-20-13-01-03-7c3c3eaf/2025-03-23T04-10-27+00-00_mmmu-multiple-choice_7DCgBa4fykTv9MaUCfRDcB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Emg5DATRZUWVSCoLkjpzXr.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_YJ25aAF3PBLurAPW7pzwXW.eval.dashboard.json
+    - name: mmmu_open
+      default_scorer: model_graded_fact
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
     reasoning:
-      - name: bbh
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_RxchDcsLppFHA6kuwuoL83.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/grok+grok-2-1212/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_7JZNhgQ7FMMWntRAehbxd8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-large-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XiMwuidzJjNRGBS8mXPXrW.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-small-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AaNsDsCU5ugYaqCRzsLLuR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o-mini/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AkBF6Ze93sPLZdmaxeXbDX.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_49YhWkhkFcFtfCn37QQqqo.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o1-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_DbxAEA7wvfePoAddRcza57.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o3-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_LYiUYn24dFUB6YDXUwwBCR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-chat/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XisL3dpLtjBf9zWcWxjYrg.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-r1/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-46-14+00-00_bbh_bU42pEgKVLkSzdpqvx33cG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_Gh8QAFG2USJs2mEZx4tGkY.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_jTfpLYU3TvLfeCLbi4GdZu.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_i4SuZzVUiusyZAPTxeXbCQ.eval.dashboard.json
-      - name: hellaswag
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-large-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_49kvsSCpeFH9eyTFoGQTpR.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-small-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_am6gMWif3hjqbftHZhLxeU.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o-mini/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_UPtLEiYzxnrk6x6o8KXFWG.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_b5kiBjmiJf99RxmCd7kVcc.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-21-467ef46a/2025-03-19T12-59-50+00-00_hellaswag_5jhMUpwnaNAwRmVpumSQ8y.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_mr2625xZk54gFhkAjFoC82.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_TEAke8jfAHbzSNxS7gRVei.eval.dashboard.json
-      - name: ifeval
-        default_scorer: instruction_following
-        default_metric: final_acc
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
+    - name: bbh
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_RxchDcsLppFHA6kuwuoL83.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/grok+grok-2-1212/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_7JZNhgQ7FMMWntRAehbxd8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-large-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XiMwuidzJjNRGBS8mXPXrW.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/mistral+mistral-small-latest/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AaNsDsCU5ugYaqCRzsLLuR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o-mini/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_AkBF6Ze93sPLZdmaxeXbDX.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+gpt-4o/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_49YhWkhkFcFtfCn37QQqqo.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o1-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_DbxAEA7wvfePoAddRcza57.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openai+o3-mini/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-14-01+00-00_bbh_LYiUYn24dFUB6YDXUwwBCR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-chat/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_XisL3dpLtjBf9zWcWxjYrg.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+deepseek+deepseek-r1/2025-03-20-00-10-55-745f1ee4/2025-03-20T00-46-14+00-00_bbh_bU42pEgKVLkSzdpqvx33cG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_Gh8QAFG2USJs2mEZx4tGkY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T03-53-59+00-00_bbh_jTfpLYU3TvLfeCLbi4GdZu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/bbh/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-19-03-50-35-693a222d/2025-03-19T04-38-58+00-00_bbh_i4SuZzVUiusyZAPTxeXbCQ.eval.dashboard.json
+    - name: hellaswag
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-large-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_49kvsSCpeFH9eyTFoGQTpR.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/mistral+mistral-small-latest/2025-03-19-03-51-21-467ef46a/2025-03-19T13-35-32+00-00_hellaswag_am6gMWif3hjqbftHZhLxeU.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o-mini/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_UPtLEiYzxnrk6x6o8KXFWG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openai+gpt-4o/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_b5kiBjmiJf99RxmCd7kVcc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+deepseek+deepseek-chat/2025-03-19-03-51-21-467ef46a/2025-03-19T12-59-50+00-00_hellaswag_5jhMUpwnaNAwRmVpumSQ8y.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_mr2625xZk54gFhkAjFoC82.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/hellaswag/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-21-467ef46a/2025-03-19T11-23-05+00-00_hellaswag_TEAke8jfAHbzSNxS7gRVei.eval.dashboard.json
+    - name: ifeval
+      default_scorer: instruction_following
+      default_metric: final_acc
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
+    - name: mmlu_pro
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-large-latest/2025-03-20-12-48-43-c03ecf66/2025-03-20T13-15-51+00-00_mmlu-pro_e6rkvFpTfqeCkmqDxTRw6F.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/mistral+mistral-small-latest/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_hanjachaAvYpLvxn4DHTbF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_M7uEBH5D9kGTcBskoAY4gV.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+gpt-4o/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_EhcDf4Wf8Gm7EeW2xZ6Km9.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o1-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_WnLxKdZNhfk4g93WAKMwoN.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openai+o3-mini/2025-03-20-12-48-43-c03ecf66/2025-03-22T02-09-15+00-00_mmlu-pro_FJESccDWrQr4H9sBzWjYU6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+deepseek+deepseek-chat/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_7vYtuAjLAzPcCn5eKBPtjK.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-22T06-22-12+00-00_mmlu-pro_WTRJmiyXh67zVWkJAdHRUb.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmlu_pro/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-48-43-c03ecf66/2025-03-23T03-05-39+00-00_mmlu-pro_LNoD7YebCiKBwdDDQCFsjY.eval.dashboard.json
+    - name: mmmu_multiple_choice
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/mistral+mistral-small-latest/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T13-14-44+00-00_mmmu-multiple-choice_82fX75CnQT8cYarx2GUEgv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_KecRXQTPCHeDmhVucnQCsE.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+gpt-4o/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_QkEnqrGpgg9pbgUfz7f9d6.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openai+o1-mini/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_WYVgRVDJwefG2of2bLdFQv.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-chat/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Pu4wQquRtRUjjShnLLgd6h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+deepseek+deepseek-r1/2025-03-20-13-01-03-7c3c3eaf/2025-03-23T04-10-27+00-00_mmmu-multiple-choice_7DCgBa4fykTv9MaUCfRDcB.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_Emg5DATRZUWVSCoLkjpzXr.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_multiple_choice/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-01-03-7c3c3eaf/2025-03-21T11-39-29+00-00_mmmu-multiple-choice_YJ25aAF3PBLurAPW7pzwXW.eval.dashboard.json
+    - name: mmmu_open
+      default_scorer: model_graded_fact
+      default_metric: accuracy
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/mistral+mistral-small-latest/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_LD7kaNaLBGbhPgfLNCGVDJ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_NMVfJomWy7NGLy8vDmphbu.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+gpt-4o/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_V2uWnCgDwvf3LwqrY9GjXD.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openai+o1-mini/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_4riYDCCYVHkVGUJwmscUtF.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-chat/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_n7YoHfQhcNRESMEwT6MrTY.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+deepseek+deepseek-r1/2025-03-20-12-46-24-0bf3abcc/2025-03-20T15-33-28+00-00_mmmu-open_gt6cuybxF8yXAETf88FaNi.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_93fT8D5AQ9jHsSzyhS4kQG.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_cgzVcwpo9e3koUgEDCSUKy.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/mmmu_open/openrouter+qwen+qwen-2-vl-72b-instruct/2025-03-20-12-46-24-0bf3abcc/2025-03-20T13-29-43+00-00_mmmu-open_69SSzCaqxMxTWqbYdkXfPq.eval.dashboard.json
     safeguards:
-      # Temporarily using ifeval for safeguards until agentharm is available
-      - name: ifeval
-        default_scorer: instruction_following
-        default_metric: final_acc
-        paths:
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-large-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_VsbAnMKvWMFfKjccq8XCTS.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/mistral+mistral-small-latest/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_X6XwXzRjL3NuDGeNYcdSnw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o-mini/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_YGD59MLTLmdYsPo6ToU6Tw.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+gpt-4o/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_R7LEM3A5aV75oDc36PsP7m.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o1-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_b7vtnkLEx7iGCEExw7otM8.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openai+o3-mini/2025-03-20-04-37-39-6cd4c920/2025-03-20T04-40-47+00-00_ifeval_3U6NBwWFQ5KFLk4J3j2sL4.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-chat/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_i5sTjSQ4JhVqo7tv7Qomw5.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+deepseek+deepseek-r1/2025-03-20-04-37-39-6cd4c920/2025-03-20T23-24-31+11-00_ifeval_TJzhamQrcm5kUeZ7TFEWey.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_nrZLj6qBMkLc4gGHwGbXsH.eval.dashboard.json
-          - s3://$AWS_S3_BUCKET/logs/stage/ifeval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-20-13-11-35-a9deffd5/2025-03-20T13-15-43+00-00_ifeval_RFo28uu7WAzHiJ9PoLUD6p.eval.dashboard.json
-
+    - name: agentharm
+      default_scorer: combined_scorer
+      default_metric: avg_score
+      paths:
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/anthropic+claude-3-7-sonnet-20250219/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_Yj8XiXuBk4897LVyYQJycc.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/google+gemini-2.0-flash-001/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_fMtKw9EAe2bt2YSTKkiW6Y.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openai+gpt-4o-mini/2025-03-24-00-42-50-52d71604/2025-03-24T02-54-38+00-00_agentharm_Bb8NyyTVMxBtiFEnbFQg8h.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openai+gpt-4o/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_Rjoac8n7hPaGwt44bxLaTQ.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openrouter+deepseek+deepseek-chat/2025-03-24-00-42-50-52d71604/2025-03-24T03-06-50+00-00_agentharm_ABwHhTekcokE4Yc6Qscpaf.eval.dashboard.json
+      - s3://$AWS_S3_BUCKET/logs/stage/agentharm/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-24-00-42-50-52d71604/2025-03-24T02-54-38+00-00_agentharm_RC3GekdRpikexrfMV3B3Tq.eval.dashboard.json
 test:
   evaluations:
     agents:
-      - name: pubmedqa
-        default_scorer: choice
-        default_metric: accuracy
-        paths:
-          - test/data/pubmedqa/1.json
-          - test/data/pubmedqa/2.json
+    - name: pubmedqa
+      default_scorer: choice
+      default_metric: accuracy
+      paths:
+      - test/data/pubmedqa/1.json
+      - test/data/pubmedqa/2.json

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ stage:
   evaluations:
     agents:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -111,7 +111,7 @@ stage:
           - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     coding:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -123,7 +123,7 @@ stage:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
       - name: humaneval
-        default_scorer: choice
+        default_scorer: verify
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
@@ -134,7 +134,7 @@ stage:
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
       - name: mbpp
-        default_scorer: choice
+        default_scorer: verify
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
@@ -151,7 +151,7 @@ stage:
           - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
     cybersecurity:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -199,7 +199,7 @@ stage:
           - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
     knowledge:
       - name: commonsense_qa
-        default_scorer: multiple_choice
+        default_scorer: choice
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json
@@ -313,7 +313,7 @@ dev:
   evaluations:
     agents:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -353,7 +353,7 @@ dev:
           - s3://$AWS_S3_BUCKET/logs/stage/piqa/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-22-12-25-46-5c6a0194/2025-03-22T12-34-17+00-00_piqa_HWLsTLRHQkfrNaMNAkwHN9.eval.dashboard.json
     coding:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -365,7 +365,7 @@ dev:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+deepseek+deepseek-chat/2025-03-21-02-07-44-c64b7513/2025-03-22T06-28-42+00-00_cybench_dXmqoLvymm4sYQV6AEFxaL.eval.dashboard.json
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_5xiMCRagFvWTDGa4HRYYxC.eval.dashboard.json
       - name: humaneval
-        default_scorer: choice
+        default_scorer: verify
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/mistral+mistral-large-latest/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_c74dFq7SpCSUsTqpFiW7TU.eval.dashboard.json
@@ -376,7 +376,7 @@ dev:
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.2-90b-vision-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_5suLhYY2kEmshRTfR6w23f.eval.dashboard.json
           - s3://$AWS_S3_BUCKET/logs/stage/humaneval/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-19-03-51-23-dc6e825d/2025-03-20T06-52-31+00-00_humaneval_BXSpiy7578RdRrgfPkAKcj.eval.dashboard.json
       - name: mbpp
-        default_scorer: choice
+        default_scorer: verify
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/mbpp/anthropic+claude-3-7-sonnet-20250219/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_GUCjLXdSN7qv93DDx44Lrp.eval.dashboard.json
@@ -393,7 +393,7 @@ dev:
           - s3://$AWS_S3_BUCKET/logs/stage/mbpp/openrouter+qwen+qwen-2.5-coder-32b-instruct/2025-03-22-12-10-14-84fa272c/2025-03-22T12-15-17+00-00_mbpp_fCL3ba3aNDCAb4VQATgmjT.eval.dashboard.json
     cybersecurity:
       - name: cybench
-        default_scorer: choice
+        default_scorer: includes
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/cybench/anthropic+claude-3-7-sonnet-20250219/2025-03-21-02-07-44-c64b7513/2025-03-21T02-41-00+00-00_cybench_ZPheSRr2hMSwyTBfd4HxeE.eval.dashboard.json
@@ -441,7 +441,7 @@ dev:
           - s3://$AWS_S3_BUCKET/logs/stage/cyse2_interpreter_abuse/openrouter+meta-llama+llama-3.3-70b-instruct/2025-03-21-02-07-56-c293333d/2025-03-21T02-10-15+00-00_cyse2-interpreter-abuse_2MGdWcmYHYFRjtieK85iMy.eval.dashboard.json
     knowledge:
       - name: commonsense_qa
-        default_scorer: multiple_choice
+        default_scorer: choice
         default_metric: accuracy
         paths:
           - s3://$AWS_S3_BUCKET/logs/stage/commonsense_qa/anthropic+claude-3-7-sonnet-20250219/2025-03-19-03-51-07-1110860b/2025-03-19T04-59-54+00-00_commonsense-qa_hc2EKqNRpRLzZ7hFnsPiTQ.eval.dashboard.json

--- a/scripts/update_config.py
+++ b/scripts/update_config.py
@@ -93,8 +93,8 @@ def extract_model(path):
 
 def extract_timestamp(path):
     """Extract timestamp from path for sorting by recency."""
-    # First try to match the ISO timestamp format in the filename
-    match = re.search(r"(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})", path)
+    # We support both T and - as a separator
+    match = re.search(r"(\d{4}-\d{2}-\d{2}[T-]\d{2}-\d{2}-\d{2})", path)
     if match:
         return match.group(1)
 

--- a/scripts/update_config.py
+++ b/scripts/update_config.py
@@ -163,6 +163,11 @@ def create_config(paths_list, original_config=None):
 
     # Process environments in the specified order
     for env in ENV_ORDER:
+        # For 'test' environment, take directly from original config if available
+        if env == "test" and original_config and "test" in original_config:
+            config["test"] = original_config["test"]
+            continue
+
         # Skip environments that don't have any paths and aren't in original config
         if env not in env_eval_paths and (
             not original_config or env not in original_config
@@ -266,6 +271,10 @@ def check_inconsistencies(config):
 
     # Check for inconsistencies with MAPPING
     for env, env_config in config.items():
+        # Skip test environment and non-dictionary configs
+        if env == "test":
+            continue
+
         for category, evals in env_config["evaluations"].items():
             if category in MAPPING:
                 for eval_config in evals:

--- a/scripts/update_config.py
+++ b/scripts/update_config.py
@@ -1,0 +1,282 @@
+import argparse
+import os
+import re
+from collections import defaultdict
+
+import boto3
+import yaml
+
+MAPPING = {
+    "agents": ["cybench", "gaia", "gdm", "piqa", "swe_bench"],
+    "assistants": ["gaia", "piqa"],
+    "coding": ["cybench", "humaneval", "mbpp", "osworld", "swe_bench"],
+    "cybersecurity": [
+        "cybench",
+        "cyse2_vulnerability_exploit",
+        "cyse2_interpreter_abuse",
+        "cyse2_prompt_injection",
+        "gdm",
+    ],
+    "knowledge": ["commonsense_qa", "gpqa_diamond", "mmlu_pro"],
+    "mathematics": ["gsm8k", "mathvista"],
+    "multimodal": ["mathvista", "mmmu_open", "mmmu_multiple_choice"],
+    "reasoning": [
+        "bbh",
+        "hellaswag",
+        "ifeval",
+        "mmmu_open",
+        "mmmu_multiple_choice",
+        "mmlu_pro",
+    ],
+    "safeguards": ["agentharm"],
+}
+
+
+def parse_paths(paths_file=None):
+    if paths_file:
+        with open(paths_file, "r") as f:
+            paths = f.readlines()
+        paths = [path.strip() for path in paths if path.strip()]
+    else:
+        # Get paths directly from S3
+        s3 = boto3.client("s3")
+        paginator = s3.get_paginator("list_objects_v2")
+        bucket = os.environ.get("AWS_S3_BUCKET", "inspect-evals-dashboard")
+        result = []
+
+        for page in paginator.paginate(Bucket=bucket, Prefix="logs/stage/"):
+            if "Contents" in page:
+                for obj in page["Contents"]:
+                    if obj["Key"].endswith("dashboard.json"):
+                        result.append(obj["Key"])
+
+        paths = result
+
+    # Group paths by evaluation-model combination and get the most recent ones
+    eval_model_paths = defaultdict(list)
+    for path in paths:
+        eval_name = extract_eval_name(path)
+        model_name = extract_model(path)
+
+        if eval_name and model_name:
+            key = f"{eval_name}:{model_name}"
+            eval_model_paths[key].append(path)
+
+    # Sort by date and get the most recent path for each eval-model combination
+    result = []
+    for _, paths_list in eval_model_paths.items():
+        # Sort by timestamp in the path
+        sorted_paths = sorted(
+            paths_list,
+            key=lambda x: extract_timestamp(x),
+            reverse=True,  # Most recent first
+        )
+        # Take the most recent path
+        if sorted_paths:
+            result.append(sorted_paths[0])
+
+    return result
+
+
+def extract_eval_name(path):
+    """Extract evaluation name from an S3 path."""
+    match = re.search(r"logs/stage/([^/]+)/", path)
+    if match:
+        return match.group(1).lower().replace("-", "_")
+    return None
+
+
+def extract_model(path):
+    """Extract model name from an S3 path."""
+    match = re.search(r"/([^/]+\+[^/]+)/", path)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_timestamp(path):
+    """Extract timestamp from path for sorting by recency."""
+    # First try to match the ISO timestamp format in the filename
+    match = re.search(r"(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2})", path)
+    if match:
+        return match.group(1)
+
+    # Default to empty string if no timestamp found
+    return ""
+
+
+def extract_environment(path):
+    if "logs/stage/" in path:
+        return "stage"
+    elif "logs/prod/" in path:
+        return "prod"
+    elif "logs/dev/" in path:
+        return "dev"
+    return "dev"  # Default to dev if not found
+
+
+def extract_default_metrics(path):
+    # This is a stub - in reality, you would download and parse the JSON file
+    # For GSM8K, typically use "match" scorer
+    if "gsm8k" in path.lower():
+        return "match", "accuracy"
+    # For most other evaluations, use "choice" scorer
+    return "choice", "accuracy"
+
+
+def create_config(paths_list):
+    # Group paths by environment and evaluation name
+    env_eval_paths = defaultdict(lambda: defaultdict(list))
+    for path in paths_list:
+        env = extract_environment(path)
+        eval_name = extract_eval_name(path)
+        if eval_name:
+            env_eval_paths[env][eval_name].append(path)
+
+    # Create YAML config maintaining order
+    config = {}
+
+    # Create sections for each environment
+    for env in sorted(env_eval_paths.keys()):
+        config[env] = {"evaluations": {}}
+
+        # Create sections for each category in the mapping
+        for category, evals in MAPPING.items():
+            config[env]["evaluations"][category] = []
+
+            # Track if we've added any evaluations for this category
+            category_has_evals = False
+
+            # Add each evaluation in this category
+            for eval_name in evals:
+                eval_name_normalized = eval_name.lower().replace("-", "_")
+
+                if eval_name_normalized in env_eval_paths[env]:
+                    category_has_evals = True
+
+                    # Get default scorer and metric from the file
+                    default_scorer, default_metric = extract_default_metrics(
+                        env_eval_paths[env][eval_name_normalized][0]
+                    )
+
+                    eval_config = {
+                        "name": eval_name_normalized,
+                        "default_scorer": default_scorer,
+                        "default_metric": default_metric,
+                        "paths": [
+                            f"s3://$AWS_S3_BUCKET/{path}"
+                            for path in env_eval_paths[env][eval_name_normalized]
+                        ],
+                    }
+
+                    config[env]["evaluations"][category].append(eval_config)
+
+            # If no evaluations were added for this category, add placeholder
+            if not category_has_evals:
+                placeholder = {
+                    "name": "pubmedqa",
+                    "default_scorer": "choice",
+                    "default_metric": "accuracy",
+                    "paths": [
+                        f"s3://$AWS_S3_BUCKET/{env}/pubmedqa/{i}.json"
+                        for i in range(1, 6)
+                    ],
+                }
+                config[env]["evaluations"][category].append(placeholder)
+
+    # Check for inconsistencies
+    check_inconsistencies(config)
+
+    return config
+
+
+# Check for inconsistencies in the config:
+# Same logs in different parts of the config having different settings
+# Inconsistencies with MAPPING
+# Missing default_choice, default_metric
+def check_inconsistencies(config):
+    # Create a dictionary to track all paths and their settings
+    path_settings = {}
+    inconsistencies = []
+
+    # Check for duplicate paths with different settings
+    for env, env_config in config.items():
+        for category, evals in env_config["evaluations"].items():
+            for eval_config in evals:
+                for path in eval_config["paths"]:
+                    path_key = (
+                        path.split("s3://$AWS_S3_BUCKET/")[1]
+                        if "s3://$AWS_S3_BUCKET/" in path
+                        else path
+                    )
+
+                    settings = {
+                        "default_scorer": eval_config["default_scorer"],
+                        "default_metric": eval_config["default_metric"],
+                    }
+
+                    if path_key in path_settings:
+                        # Check if settings are different
+                        if path_settings[path_key] != settings:
+                            inconsistencies.append(
+                                f"Inconsistency found for path {path_key}: {path_settings[path_key]} vs {settings}"
+                            )
+                    else:
+                        path_settings[path_key] = settings
+
+    # Check for inconsistencies with MAPPING
+    for env, env_config in config.items():
+        for category, evals in env_config["evaluations"].items():
+            if category in MAPPING:
+                for eval_config in evals:
+                    if eval_config["name"] != "pubmedqa":  # Skip placeholders
+                        eval_name = eval_config["name"]
+                        if eval_name not in MAPPING[category]:
+                            inconsistencies.append(
+                                f"Inconsistency with MAPPING: {eval_name} in category {category} not in MAPPING"
+                            )
+
+    # Check for missing default_choice, default_metric
+    for env, env_config in config.items():
+        for category, evals in env_config["evaluations"].items():
+            for eval_config in evals:
+                if "default_scorer" not in eval_config:
+                    inconsistencies.append(
+                        f"Missing default_scorer in {env}/{category}/{eval_config['name']}"
+                    )
+                if "default_metric" not in eval_config:
+                    inconsistencies.append(
+                        f"Missing default_metric in {env}/{category}/{eval_config['name']}"
+                    )
+
+    # Print inconsistencies
+    if inconsistencies:
+        print("WARNING: The following inconsistencies were found:")
+        for inconsistency in inconsistencies:
+            print(f"  - {inconsistency}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate YAML config for dashboard.")
+    parser.add_argument("--output", help="Output file for YAML config (optional)")
+    args = parser.parse_args()
+
+    # Parse paths  from S3
+    paths_list = parse_paths()
+
+    # Generate config
+    config = create_config(paths_list)
+
+    # Convert to YAML
+    yaml_config = yaml.dump(config, sort_keys=False, default_flow_style=False)
+
+    # Output
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(yaml_config)
+    else:
+        print(yaml_config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_config.py
+++ b/scripts/update_config.py
@@ -305,6 +305,27 @@ def check_inconsistencies(config):
             print(f"  - {inconsistency}")
 
 
+def extract_comments(file_path):
+    """Extract comments from the top of the original file."""
+    comments = []
+    if not os.path.exists(file_path):
+        return comments
+
+    with open(file_path, "r") as f:
+        for line in f:
+            if line.strip().startswith("#"):
+                comments.append(line.rstrip())
+            elif not line.strip():
+                # Keep empty lines between comments
+                if comments and comments[-1]:
+                    comments.append("")
+            else:
+                # Stop once we hit non-comment, non-empty line
+                break
+
+    return comments
+
+
 def main():
     parser = argparse.ArgumentParser(description="Generate YAML config for dashboard.")
     parser.add_argument(
@@ -315,7 +336,12 @@ def main():
 
     # Load original config if provided
     original_config = None
+    comments = []
     if args.input:
+        # Extract comments from the top of the file
+        comments = extract_comments(args.input)
+
+        # Load the YAML content
         with open(args.input, "r") as f:
             original_config = yaml.safe_load(f)
 
@@ -327,6 +353,10 @@ def main():
 
     # Convert to YAML
     yaml_config = yaml.dump(config, sort_keys=False, default_flow_style=False)
+
+    # Prepend comments
+    if comments:
+        yaml_config = "\n".join(comments) + "\n" + yaml_config
 
     # Output
     if args.output:


### PR DESCRIPTION
The script updates the config with the new paths from S3 if run via the following command:

```
AWS_S3_BUCKET=inspect-evals-dashboard python3 scripts/update_config.py --input config.yml --output config.yml
```

Key points:
1. It downloads paths and takes the most recent ones for each eval-model pairs.
2. Defaults to the original config for the `default_scorer` and `default_metric` if there are values set and checks them against the actual file. Otherwise takes the first scorer/metric from the file.
3. Cross-checks for a bunch of different inconsistencies in the resulting config (such as the same eval having different scorers in different categories.
4. Prints categories in the lexicographic order in order to generate nice diffs.