### PR TITLE
Fix the home page crashing on the second load

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,10 +45,6 @@ def home_content():
     if SENTRY_DSN:
         sentry_patch_streamlit()
 
-    template = pio.templates[pio.templates.default]
-    template.layout.hoverlabel.align = "left"  # make tooltips consistently aligned
-    pio.templates.default = template
-
     # Global styles
     st.markdown(
         """
@@ -201,6 +197,17 @@ def home_content():
         ```
     """
     )
+
+
+# Initially pio.templates.default is a name of one of the preset templates
+# We pull that template, update it and then set the object as default (rather than the name)
+#
+# To make sure this code works correctly and isn't executed twice we check
+# if the default template is a string (i.e. a name, and not an object yet)
+if isinstance(pio.templates.default, str):
+    template = pio.templates[pio.templates.default]
+    template.layout.hoverlabel.align = "left"  # make tooltips consistently aligned
+    pio.templates.default = template
 
 
 home = st.Page(home_content, title="Home", icon="🏠", default=True)


### PR DESCRIPTION
The crash happens because the code for updating the plotly theme gets run twice and with different types. I put it under an if condition. 

I also double-checked just in case that `plotly.io.templates.default` can be both a string and an object, and [this is indeed supported](https://github.com/plotly/plotly.py/blob/94790d27f13d637b95d58b98c3000733a78ce21f/plotly/basedatatypes.py#L2525).