### PR TITLE
Use screen space more efficiently

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,16 @@ st.markdown(
     <style>
     .stMainBlockContainer.block-container {
         max-width: 1024px;
-        padding-top: 20px;
+        padding-top: 16px;
+    }
+
+    .stMainBlockContainer.block-container h1,
+    .stMainBlockContainer.block-container h2,
+    .stMainBlockContainer.block-container h3,
+    .stMainBlockContainer.block-container h4,
+    .stMainBlockContainer.block-container h5,
+    .stMainBlockContainer.block-container h6 {
+      padding-bottom: 6px;
     }
 
     .flex-center-container {

--- a/app.py
+++ b/app.py
@@ -16,6 +16,34 @@ if SENTRY_DSN:
         send_default_pii=True,
     )
 
+st.set_page_config(
+    page_title="Inspect Evals Dashboard", page_icon="🤖", layout="centered"
+)
+
+# Global styles
+st.markdown(
+    """
+    <style>
+    .stMainBlockContainer.block-container {
+        max-width: 1024px;
+        padding-top: 20px;
+    }
+
+    .flex-center-container {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100%;
+        width: 100%;
+    }
+    .header-without-anchor span {
+        display: none !important;
+    }
+    </style>
+""",
+    unsafe_allow_html=True,
+)
+
 
 # There is no official sentry/streamlit integration
 # But people found some workarounds in the discussion:
@@ -37,33 +65,11 @@ def sentry_patch_streamlit():
     script_runner.handle_uncaught_app_exception = sentry_patched_func
 
 
+if SENTRY_DSN:
+    sentry_patch_streamlit()
+
+
 def home_content():
-    st.set_page_config(
-        page_title="Inspect Evals Dashboard", page_icon="🤖", layout="centered"
-    )
-
-    if SENTRY_DSN:
-        sentry_patch_streamlit()
-
-    # Global styles
-    st.markdown(
-        """
-        <style>
-        .flex-center-container {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100%;
-            width: 100%;
-        }
-        .header-without-anchor span {
-            display: none !important;
-        }
-        </style>
-    """,
-        unsafe_allow_html=True,
-    )
-
     st.title("Inspect Evals Dashboard")
 
     st.markdown(

--- a/src/pages/evaluations/template.py
+++ b/src/pages/evaluations/template.py
@@ -18,9 +18,10 @@ from src.plots.plot_utils import highlight_confidence_intervals
 def render_page(
     eval_logs: list[DashboardLog], default_values: dict[str, dict[str, str]]
 ):
-    st.subheader("Naive cross-model comparison")
     st.markdown("""
-                Graphs in this section compare how different AI models perform on the same task. We call this a "naive" comparison because it uses simple averages to compare models, without determining if one model is statistically significantly better than another. To get more accurate scores, we evaluate each sample in a dataset multiple times using the epochs feature in Inspect AI. For more reliable statistical comparisons between models, check out the pairwise analysis in the next section.
+                ### Naive cross-model comparison
+                Uses simple averages to compare models, without determining if one model is statistically significantly better than another. For more accurate scores, we evaluate each sample in a dataset multiple times using the epochs feature in Inspect AI.
+
                 """)
 
     col1, col2, col3, col4 = st.columns(4)
@@ -97,15 +98,19 @@ def render_page(
     if family_filtered_logs:
         # Display evaluation details from the first log entry
         eval_details = family_filtered_logs[0]
-        st.text("")  # Add a blank line for spacing
-        st.markdown("##### Evaluation details:")
-        st.markdown(f"""
-                    - **Name:** {eval_details.eval_metadata.title}
-                    - **Description:** {eval_details.eval_metadata.description}
-                    - **ArXiv:** {eval_details.eval_metadata.arxiv}
-                    - **Task path in Inspect Evals:** [{eval_details.eval_metadata.path}](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/{eval_details.eval_metadata.path})
-                    """)
-        st.text("")  # Add a blank line for spacing
+
+        # Use simple html to make the overall layout tighter
+        st.markdown(
+            f"""
+            <div>
+                <h5 style="padding-bottom: 5px;">{eval_details.eval_metadata.title}</h5>
+                {eval_details.eval_metadata.description}<br>
+                <a href="https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/{eval_details.eval_metadata.path}">ArXiv</a> ·
+                <a href="https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/{eval_details.eval_metadata.path}">Github</a>
+            </div>
+            """,
+            unsafe_allow_html=True,
+        )
 
         scorer = default_values[naive_task_name]["default_scorer"]
 


### PR DESCRIPTION
# Screenshots

## Before

<img width="1506" alt="image" src="https://github.com/user-attachments/assets/ba06ad96-98e6-43ad-8530-89c71626fab2" />


## After

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4bcd1159-3692-4039-bef0-2c806bad0ad8" />


# Description

Progress on the two remaining feedback items. If you feel like this PR doesn't address the items completely, let me know. There are further changes that can be made. For example, I haven't worked on the copy directly below the top heading.
 
1. "Have the graphs above the fold instead of lots of text first (shorten text or move to expandables)"
a) I increased the max-width of the main block to 1024 px. This is fairly standard size many websites use that's not too wide. In addition to pullin up charts  it also makes charts themselves wider — this helps better convey distinctions between data.
b) I reduced the topmost block top padding significantly to pull the entire page up. There is no particular reason for it to be so low by default.
c) I shorten the eval description block. It's currently 80px. For comparison, an expandable isn't much shorter — it has a height of 45 px — it wouldn't save much time. 
4) I also reduced the padding on headings — primarily to pull them closer to their text to make them visually grouping. But it also saved some pixel time.

After this PR: the first chart starts at 482 px on my laptop.
Before this PR: the first chart starts at 855 px.

2. "Have the input widgets adjacent to the graphs (move eval details out of the way as needed)" — I reduced the amount of unnecessary text tightening the block to 80 px. Putting it under an expandable would save only 35 px since expandables are 45px.



