### PR TITLE
Shorten eval categories descriptions

### DIFF
--- a/src/pages/evaluations/agents.py
+++ b/src/pages/evaluations/agents.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Agentic Evaluations")
 
 st.markdown("""
-            Pursuing goals and making decisions autonomously without constant human guidance. Agentic evaluations measure how effectively these systems perform in multi-step challenges that require planning, reasoning, and adaptation. These evaluations assess the AI's ability to decompose tasks, navigate environments, select appropriate tools, maintain alignment with goals, and recover from failures.
+            Agentic evaluations measure how effectively AI systems perform in multi-step challenges that require planning, reasoning, and adaptation. They assess the AI's ability to decompose tasks, navigate environments, select appropriate tools, maintain alignment with goals, and recover from failures.
             """)
 
 group_config: list[EvaluationConfig] = load_config().agents

--- a/src/pages/evaluations/agents.py
+++ b/src/pages/evaluations/agents.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Agentic Evaluations")
 
 st.markdown("""
-            Agentic capabilities enable AI systems to pursue goals and make decisions autonomously without constant human guidance. Agentic evaluations measure how effectively these systems perform in multi-step challenges that require planning, reasoning, and adaptation. These evaluations assess the AI's ability to decompose tasks, navigate environments, select appropriate tools, maintain alignment with goals, and recover from failures.
+            Pursuing goals and making decisions autonomously without constant human guidance. Agentic evaluations measure how effectively these systems perform in multi-step challenges that require planning, reasoning, and adaptation. These evaluations assess the AI's ability to decompose tasks, navigate environments, select appropriate tools, maintain alignment with goals, and recover from failures.
             """)
 
 group_config: list[EvaluationConfig] = load_config().agents

--- a/src/pages/evaluations/coding.py
+++ b/src/pages/evaluations/coding.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Coding Evaluations")
 
 st.markdown("""
-            Generating, modifying, and understanding code across programming languages. These evaluations test multiple dimensions including functional correctness, problem-solving ability, code quality, language breadth, contextual understanding, security awareness, and documentation. Assessment methods include challenge datasets, unit tests, human expert review, and automated code analysis.
+            Coding evaluations assess AI systems' ability to generate, modify, and understand code across programming languages. These evaluations test multiple dimensions including functional correctness, problem-solving ability, code quality, language breadth, contextual understanding, security awareness, and documentation.
             """)
 
 group_config: list[EvaluationConfig] = load_config().coding

--- a/src/pages/evaluations/coding.py
+++ b/src/pages/evaluations/coding.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Coding Evaluations")
 
 st.markdown("""
-            Coding evaluations measure how effectively AI systems generate, modify, and understand code across programming languages. These evaluations test multiple dimensions including functional correctness, problem-solving ability, code quality, language breadth, contextual understanding, security awareness, and documentation. Assessment methods include challenge datasets, unit tests, human expert review, and automated code analysis.
+            Generating, modifying, and understanding code across programming languages. These evaluations test multiple dimensions including functional correctness, problem-solving ability, code quality, language breadth, contextual understanding, security awareness, and documentation. Assessment methods include challenge datasets, unit tests, human expert review, and automated code analysis.
             """)
 
 group_config: list[EvaluationConfig] = load_config().coding

--- a/src/pages/evaluations/cybersecurity.py
+++ b/src/pages/evaluations/cybersecurity.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Cybersecurity Evaluations")
 
 st.markdown("""
-            Testing practical security skills through realistic hacking challenges and capture-the-flag competitions. Also measuring fundamental cybersecurity knowledge using structured questionnaires and multiple-choice assessments. Some evaluations examine potentially dangerous capabilities like vulnerability exploitation and prompt injection resistance, while others focus on incident analysis and response skills.
+            Cybersecurity evaluations assess security skills through practical hacking challenges, CTF competitions, and knowledge-based questionnaires. Some examine potentially dangerous capabilities like vulnerability exploitation and prompt injection resistance, while others focus on incident analysis and response skills.
             """)
 
 group_config: list[EvaluationConfig] = load_config().cybersecurity

--- a/src/pages/evaluations/cybersecurity.py
+++ b/src/pages/evaluations/cybersecurity.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Cybersecurity Evaluations")
 
 st.markdown("""
-            Cybersecurity evaluations test practical security skills through realistic hacking challenges and capture-the-flag competitions. They can also measure fundamental cybersecurity knowledge using structured questionnaires and multiple-choice assessments. Some evaluations specifically examine potentially dangerous capabilities like vulnerability exploitation and prompt injection resistance, while others focus on incident analysis and response skills.
+            Testing practical security skills through realistic hacking challenges and capture-the-flag competitions. Also measuring fundamental cybersecurity knowledge using structured questionnaires and multiple-choice assessments. Some evaluations examine potentially dangerous capabilities like vulnerability exploitation and prompt injection resistance, while others focus on incident analysis and response skills.
             """)
 
 group_config: list[EvaluationConfig] = load_config().cybersecurity

--- a/src/pages/evaluations/knowledge.py
+++ b/src/pages/evaluations/knowledge.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Knowledge Evaluations")
 
 st.markdown("""
-            Assessing intellectual capabilities across multiple dimensions. Measuring breadth of factual knowledge in diverse domains (sciences, humanities, law), depth of understanding in specialized fields, and reasoning abilities on complex problems. Rather than just measuring simple fact retrieval, these benchmarks evaluate how AI systems apply knowledge  and integrate understanding across different domains and tasks.
+            Knowledge evaluations assess how systems apply knowledge, reason through problems, avoid misconceptions, and integrate understanding across domains, rather than just testing fact retrieval.
             """)
 
 group_config: list[EvaluationConfig] = load_config().knowledge

--- a/src/pages/evaluations/knowledge.py
+++ b/src/pages/evaluations/knowledge.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Knowledge Evaluations")
 
 st.markdown("""
-            Knowledge evaluations assess intellectual capabilities across multiple dimensions. They measure breadth of factual knowledge in diverse domains (sciences, humanities, law), depth of understanding in specialized fields, and reasoning abilities on complex problems. These evaluations also test common sense understanding, academic proficiency at various educational levels, truthfulness when addressing potentially misleading questions, and appropriate response calibration between safe and unsafe queries. Rather than just measuring simple fact retrieval, these benchmarks evaluate how AI systems apply knowledge, reason through complex problems, avoid common misconceptions, and integrate understanding across different domains and tasks.
+            Assessing intellectual capabilities across multiple dimensions. Measuring breadth of factual knowledge in diverse domains (sciences, humanities, law), depth of understanding in specialized fields, and reasoning abilities on complex problems. Rather than just measuring simple fact retrieval, these benchmarks evaluate how AI systems apply knowledge  and integrate understanding across different domains and tasks.
             """)
 
 group_config: list[EvaluationConfig] = load_config().knowledge

--- a/src/pages/evaluations/mathematics.py
+++ b/src/pages/evaluations/mathematics.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Mathematics Evaluations")
 
 st.markdown("""
-            Mathematics evaluations test a range of problem-solving skills, from basic grade school word problems to advanced competition-level mathematics. These assessments evaluate multilingual mathematical understanding across diverse languages and measure reasoning abilities when mathematics is presented in visual contexts. Additionally, they examine how these capabilities transfer across different formats, languages, and presentation modalities.
+            Testing a range of problem-solving skills, from basic grade school word problems to advanced competition-level mathematics. These assessments evaluate multilingual mathematical understanding across diverse languages and measure reasoning abilities when mathematics is presented in visual contexts. They also examine how these capabilities transfer across formats, languages, and presentation modalities.
             """)
 
 group_config: list[EvaluationConfig] = load_config().mathematics

--- a/src/pages/evaluations/mathematics.py
+++ b/src/pages/evaluations/mathematics.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Mathematics Evaluations")
 
 st.markdown("""
-            Testing a range of problem-solving skills, from basic grade school word problems to advanced competition-level mathematics. These assessments evaluate multilingual mathematical understanding across diverse languages and measure reasoning abilities when mathematics is presented in visual contexts. They also examine how these capabilities transfer across formats, languages, and presentation modalities.
+            Mathematics evaluations assess problem-solving skills across difficulty levels from elementary word problems to advanced competition mathematics. They also examine how mathematical capabilities transfer between different formats, languages, and presentation modalities.
             """)
 
 group_config: list[EvaluationConfig] = load_config().mathematics

--- a/src/pages/evaluations/multimodal.py
+++ b/src/pages/evaluations/multimodal.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Multimodal Evaluations")
 
 st.markdown("""
-            Testing an AI system's ability to process, understand, and generate content across multiple types of data simultaneously. These assessments move beyond text-only testing by incorporating diverse inputs and outputs including images, text, audio, video, and structured data.
+            Multimodal evaluations assess AI systems' abilities to process, understand, and generate content across multiple data types simultaneously (images, text, audio, video, and structured data).
             """)
 
 group_config: list[EvaluationConfig] = load_config().multimodal

--- a/src/pages/evaluations/multimodal.py
+++ b/src/pages/evaluations/multimodal.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Multimodal Evaluations")
 
 st.markdown("""
-            Multimodal evaluations test an AI system's ability to process, understand, and generate content across multiple types of data simultaneously. These assessments move beyond text-only testing by incorporating diverse inputs and outputs including images, text, audio, video, and structured data. The evaluations focus on cross-modal understanding, multimodal reasoning, real-world task performance, and robustness across different information types. This comprehensive testing is crucial as AI systems increasingly need to operate like humans in environments where information comes in multiple forms rather than single data streams.
+            Testing an AI system's ability to process, understand, and generate content across multiple types of data simultaneously. These assessments move beyond text-only testing by incorporating diverse inputs and outputs including images, text, audio, video, and structured data.
             """)
 
 group_config: list[EvaluationConfig] = load_config().multimodal

--- a/src/pages/evaluations/reasoning.py
+++ b/src/pages/evaluations/reasoning.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Reasoning Evaluations")
 
 st.markdown("""
-            Asessing comprehension, logical inference, common sense understanding, instruction following, and information processing from various contexts and modalities. These benchmarks test how effectively AI systems can handle challenges involving mathematics, spatial reasoning, physical understanding, and extended context information.
+            Reasoning evaluations assess comprehension, logical inference, common sense understanding, instruction following, and information processing across contexts and modalities. They test AI systems' effectiveness in handling mathematics, spatial reasoning, physical understanding, and extended context challenges.
             """)
 
 group_config: list[EvaluationConfig] = load_config().reasoning

--- a/src/pages/evaluations/reasoning.py
+++ b/src/pages/evaluations/reasoning.py
@@ -8,7 +8,7 @@ from src.pages.evaluations.template import render_page
 st.title("Reasoning Evaluations")
 
 st.markdown("""
-            Reasoning evaluations assess abilities in comprehension, logical inference, common sense understanding, instruction following, and information processing from various contexts and modalities. These benchmarks test how effectively AI systems can handle challenges involving mathematics, spatial reasoning, physical understanding, and extended context information.
+            Asessing comprehension, logical inference, common sense understanding, instruction following, and information processing from various contexts and modalities. These benchmarks test how effectively AI systems can handle challenges involving mathematics, spatial reasoning, physical understanding, and extended context information.
             """)
 
 group_config: list[EvaluationConfig] = load_config().reasoning


### PR DESCRIPTION
I shortened them to be < 3 lines on my laptop. I started by dropping the first few words since they would repeat the name of the evaluation. I then edited to make all descriptions fit on < 3 lines on my laptop — they naturally tended to have this length.

If you'd like a more aggressive pass — let me know.