### PR TITLE
Barchart: add hack for showing tooltips when the value of a bar is 0

### DIFF
--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -16,7 +16,11 @@ def create_bar_chart(
 
     metric_values = [
         next(
-            v.value
+            # TODO: find a proper solution for displaying bar for 0.0 values.
+            # Without this hack the bars would be empty and no tooltips would be shown for them.
+            # With this hack the tooltip still shows 0.0 (as it should).
+            # That said, getting the tooltip displayed requires some amount of "pixel hunting"
+            v.value if v.value > (3 * 1e-4) else (3 * 1e-4)
             for k, v in get_scorer_by_name(log, scorer).metrics.items()
             if k == metric
         )


### PR DESCRIPTION
# Description

This makes the bar chart less confusing when the bar has a value of zero by showing the tooltips. This is a hack, but since we are about to launch I figured I'd rather not spend a lot of time on finding a proper solution.

# Screenshots

## After

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/f864cffb-36f4-4e85-bb99-cb1d04aa84f0" />

## Before

<img width="1089" alt="image" src="https://github.com/user-attachments/assets/d18f9ae1-0729-44ab-a0b3-362d67895c41" />
