### PR TITLE
Remove the hack for zero bar

### DIFF
--- a/src/plots/bar.py
+++ b/src/plots/bar.py
@@ -16,11 +16,7 @@ def create_bar_chart(
 
     metric_values = [
         next(
-            # TODO: find a proper solution for displaying bar for 0.0 values.
-            # Without this hack the bars would be empty and no tooltips would be shown for them.
-            # With this hack the tooltip still shows 0.0 (as it should).
-            # That said, getting the tooltip displayed requires some amount of "pixel hunting"
-            v.value if v.value > (3 * 1e-4) else (3 * 1e-4)
+            v.value
             for k, v in get_scorer_by_name(log, scorer).metrics.items()
             if k == metric
         )


### PR DESCRIPTION

<img width="1094" alt="image" src="https://github.com/user-attachments/assets/1e55d4ec-7e66-4e25-9eb0-0e1103ec43f8" />


This hack makes data displayed incorrectly when a bunch of filters are selected — see above. I think we need a better solution for 0s. The solution might even look similar to this hack but when we are representing the data. That said, to start with we should definitely remove this hack.  