### PR TITLE
Set location of dashboard logs from downloaded path

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import os
 import re
+from pathlib import Path
 
 import streamlit as st
 import yaml
@@ -77,7 +78,7 @@ def load_config() -> EnvironmentConfig:
     """Load evaluation logs configuration from config.yml."""
     env = os.getenv("STREAMLIT_ENV", "dev")
 
-    config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.yml")
+    config_path = Path(__file__).parent.parent / "config.yml"
     try:
         with open(config_path, "r") as f:
             raw_config = yaml.safe_load(f)

--- a/src/config.py
+++ b/src/config.py
@@ -74,7 +74,7 @@ class EnvironmentConfig(BaseModel):
 
 @st.cache_data
 def load_config() -> EnvironmentConfig:
-    """Load evaluation logs configuration from config.yaml."""
+    """Load evaluation logs configuration from config.yml."""
     env = os.getenv("STREAMLIT_ENV", "dev")
 
     config_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "config.yml")

--- a/src/log_utils/aws_s3_utils.py
+++ b/src/log_utils/aws_s3_utils.py
@@ -40,7 +40,7 @@ def create_presigned_url(
 def parse_s3_url_for_presigned_url(s3_url: str) -> tuple[str, str]:
     """Parse an S3 URL and return the bucket name and object name.
 
-    Note, that `.zip` is appended to the object name.
+    Note that the object name is transformed from the dashboard JSON path to the eval zip path.
 
     Args:
         s3_url (str): The S3 URL to parse
@@ -50,4 +50,12 @@ def parse_s3_url_for_presigned_url(s3_url: str) -> tuple[str, str]:
 
     """
     o = urlparse(s3_url, allow_fragments=False)
-    return o.netloc, o.path.lstrip("/") + ".zip"
+    bucket_name = o.netloc
+    dashboard_log_key = o.path.lstrip("/")
+
+    # Transform dashboard JSON path to eval zip path
+    # From: logs/prod/.../filename.eval.dashboard.json
+    # To:   logs/prod/.../filename.eval.zip
+    zipped_eval_log_key = dashboard_log_key.replace(".dashboard.json", ".zip")
+
+    return bucket_name, zipped_eval_log_key

--- a/src/log_utils/load_eval_logs.py
+++ b/src/log_utils/load_eval_logs.py
@@ -41,7 +41,7 @@ def load_evaluation_logs(evaluation_paths: list[str]) -> list[DashboardLog]:
             data = load_json_from_s3(path, conn)
         else:
             data = load_json_from_local(path)
-        data["location"] = path  # Set location from downloaded path
+        data["location"] = path  # Set location of DashboardLog from downloaded path
         dashboard_logs.append(DashboardLog(**data))
 
     return dashboard_logs

--- a/src/log_utils/load_eval_logs.py
+++ b/src/log_utils/load_eval_logs.py
@@ -41,6 +41,7 @@ def load_evaluation_logs(evaluation_paths: list[str]) -> list[DashboardLog]:
             data = load_json_from_s3(path, conn)
         else:
             data = load_json_from_local(path)
+        data["location"] = path  # Set location from downloaded path
         dashboard_logs.append(DashboardLog(**data))
 
     return dashboard_logs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,21 @@
+import os
+
 import pytest
 from src.config import load_config
 from src.log_utils.load_eval_logs import get_log_paths, load_evaluation_logs
+
+# Set default environment variables needed for testing
+os.environ.setdefault("AWS_S3_BUCKET", "test-bucket")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_test_env_vars():
+    """Set environment variables needed for all tests."""
+    # This ensures the environment variable is set for all tests
+    # even if they use monkeypatch which resets environment variables
+    os.environ["AWS_S3_BUCKET"] = "test-bucket"
+    os.environ["STREAMLIT_ENV"] = "test"
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_load_eval_logs.py
+++ b/tests/test_load_eval_logs.py
@@ -22,4 +22,6 @@ def test_load_evaluation_logs(eval_logs):
 
     with open("tests/data/test_task/1.json") as f:
         data = json.load(f)
+        # Location is set by load_evaluation_logs to the path the file was downloaded from
+        data["location"] = "tests/data/test_task/1.json"
         assert DashboardLog(**data) == eval_logs[0]


### PR DESCRIPTION
This should fix the issue with eval log download links.
The location is now set by the consuming code when downloading the DashboardLog, the same way `read_eval_log` works with `EvalLog` objects.