### PR TITLE
Fix double counting models, evals, runs on home page

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,7 +145,7 @@ def home_content():
         # Add model selector
         selected_model = st.selectbox(
             "Select a model to view its performance",
-            sorted(all_models),
+            sorted(all_models, key=str.lower),
             help="Choose a model to see its performance across different evaluation categories",
         )
 

--- a/src/config.py
+++ b/src/config.py
@@ -18,7 +18,7 @@ class EvaluationConfig(BaseModel):
         models = set()
         for path in self.paths:
             # Extract model name from path like: s3://$AWS_S3_BUCKET/logs/prod/bbh/anthropic+claude-3-7-sonnet-20250219/...
-            match = re.search(r'/logs/\w+/\w+/([^/]+)/', path)
+            match = re.search(r"/logs/\w+/\w+/([^/]+)/", path)
             if match:
                 models.add(match.group(1))
         return models
@@ -68,7 +68,9 @@ class EnvironmentConfig(BaseModel):
     @property
     def total_tasks(self) -> int:
         # Get unique task names across all categories
-        unique_tasks = {task.name for field in self.model_fields for task in getattr(self, field)}
+        unique_tasks = {
+            task.name for field in self.model_fields for task in getattr(self, field)
+        }
         return len(unique_tasks)
 
     @property

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,17 @@ class EvaluationConfig(BaseModel):
     paths: list[str]
 
     @property
+    def model_names(self) -> set[str]:
+        """Extract model names from paths."""
+        models = set()
+        for path in self.paths:
+            # Extract model name from path like: s3://$AWS_S3_BUCKET/logs/prod/bbh/anthropic+claude-3-7-sonnet-20250219/...
+            match = re.search(r'/logs/\w+/\w+/([^/]+)/', path)
+            if match:
+                models.add(match.group(1))
+        return models
+
+    @property
     def prefixed_name(self) -> str:
         return f"inspect_evals/{self.name}"
 
@@ -56,20 +67,29 @@ class EnvironmentConfig(BaseModel):
 
     @property
     def total_tasks(self) -> int:
-        return sum(len(getattr(self, field)) for field in self.model_fields)
+        # Get unique task names across all categories
+        unique_tasks = {task.name for field in self.model_fields for task in getattr(self, field)}
+        return len(unique_tasks)
 
     @property
     def total_runs(self) -> int:
-        return sum(
-            len(task.paths)
-            for field in self.model_fields
-            for task in getattr(self, field)
-        )
+        unique_paths = set()
+        for field in self.model_fields:
+            for task in getattr(self, field):
+                for path in task.paths:
+                    unique_paths.add(path)
+
+        return len(unique_paths)
 
     @property
     def total_models(self) -> int:
-        # This is an imperfect proxy to get the number of models from the first task in knowledge
-        return len(self.knowledge[0].paths) if self.knowledge else 0
+        # Extract all unique model names from all paths
+        all_models = set()
+        for field in self.model_fields:
+            for task in getattr(self, field):
+                all_models.update(task.model_names)
+
+        return len(all_models)
 
 
 @st.cache_data


### PR DESCRIPTION
# Decription

1. Fixes double-counting of models, evals, runs
2. Additionally properly sorts the dropdown for `Model Performance Overview` (alphabetically, case-insensitive)

# Screesnhots

## Before

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/8f5add32-1a76-45b7-addf-22d0f7e00be5" />

## After

<img width="1280" alt="image" src="https://github.com/user-attachments/assets/fe7cf217-1a35-448b-adab-e34345cf88eb" />
